### PR TITLE
Use safe vector operations and initialize ring vectors in writepoly.cpp

### DIFF
--- a/cfemm/fmesher/writepoly.cpp
+++ b/cfemm/fmesher/writepoly.cpp
@@ -50,6 +50,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #ifndef REAL
 #define REAL double
@@ -1715,11 +1716,10 @@ int FMesher::DoPeriodicBCTriangulation(string PathName)
 				}
 			}
 		}
-        agelst[n]->nodeNums.clear ();
-		agelst[n]->nodeNums.shrink_to_fit ();
-		agelst[n]->nodeNums.reserve (myVector.size()+1);
-		agelst[n]->nodeNums[0]=(int) myVector.size();
-		for(k=0;k<(int)myVector.size();k++) agelst[n]->nodeNums[k+1]=myVector[k];
+
+		agelst[n]->nodeNums.resize (myVector.size() + 1);
+		agelst[n]->nodeNums[0] = static_cast<int>(myVector.size());
+		std::copy(myVector.begin(), myVector.end(), agelst[n]->nodeNums.begin() + 1);
 	}
 
 
@@ -1852,27 +1852,19 @@ int FMesher::DoPeriodicBCTriangulation(string PathName)
 	fprintf(fp,"%i\n",(int) agelst.size());
 	for(k=0;k<(int)agelst.size();k++)
 	{
-		double dtta;
-		std::vector<CQuadPoint> InnerRing;
-		std::vector<CQuadPoint> OuterRing;
-		InnerRing.clear();
-		InnerRing.shrink_to_fit();
-		OuterRing.clear();
-		OuterRing.shrink_to_fit();
+		n = agelst[k]->nodeNums[0] / 2;
+		const double dtta = agelst[k]->totalArcLength / n;
+		n0 = static_cast<int>(round(360.0 / dtta)); // total elements in a 360deg annular ring;
+		n1 = static_cast<int>(round(360.0 / agelst[k]->totalArcLength)); // number of copied segments
 
-		n=agelst[k]->nodeNums[0]/2;
-		dtta = agelst[k]->totalArcLength/n;
-		n0=(int) round(360./dtta); // total elements in a 360deg annular ring;
-		n1=(int) round(360./agelst[k]->totalArcLength); // number of copied segments
+		std::vector<CQuadPoint> InnerRing(n0);
+		std::vector<CQuadPoint> OuterRing(n0);
 
 		// Should do some consistency checking here;
 		//   totalArcLength*n1 should equal 360
 		//   no*dtta should equal 360
 		//   if antiperiodic, n1 should be an even number
 		//   otherwise, throw error message, clean up, and return
-
-		InnerRing.reserve(n0);
-		OuterRing.reserve(n0);
 
 		// map each bdry point onto points on the ring;
 		int kk;


### PR DESCRIPTION
### Motivation

- Fix unsafe vector usage that could write past capacity and cause undefined behavior when populating `agelst[*]->nodeNums` and when preparing inner/outer ring point lists.
- Improve clarity and correctness of numeric conversions and intermediate variable lifetimes.

### Description

- Added `#include <algorithm>` and replaced manual `clear`/`reserve`/index-assignment on `nodeNums` with `resize` and `std::copy` to safely populate the vector. 
- Pre-allocated `InnerRing` and `OuterRing` using `std::vector<CQuadPoint>(n0)` instead of constructing empty vectors and then reserving, simplifying initialization. 
- Made `dtta` a `const double` and used `static_cast<int>` for `n0`/`n1` assignment to make conversions explicit. 
- Removed redundant `clear`/`shrink_to_fit`/`reserve` calls and tightened a few local variable declarations for clarity.

### Testing

- Built the project using `make` which completed successfully. 
- Ran the available automated test suite with `ctest`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63e63516708326ad1a649b19df2313)