### PR TITLE
Preserve Triangle markers/attributes in SolverMesh; add periodic/AGE support and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,37 @@ mfemm_setup('ForceMexRecompile', true)  % Forces recompilation of MEX files
 - Read by post-processors (`fpproc`, `epproc`, `hpproc`)
 - Accessible via MATLAB via MEX interface
 
+### Periodic, Air-Gap, and Sliding-Mesh Workflows
+
+- `.pbc` means **periodic boundary conditions**; it is not an air-gap-only
+  format. The file's primary section contains pairs of mesh-node indices and a
+  periodic/antiperiodic flag. Solvers use these pairs to constrain equivalent
+  degrees of freedom. This applies to any periodic model, such as a sector of a
+  complete rotary electrical machine, even when the model has no air gap.
+- Ordinary periodic and antiperiodic boundaries pair corresponding nodes on two
+  boundary segments or arcs. In magnetic problem files these are boundary
+  formats 4 and 5. Electrostatic and heat-flow problems use their own numeric
+  boundary-format values, so code should prefer `CBoundaryProp::isPeriodic()`
+  over assuming the magnetic numbers are universal.
+- Magnetic **Air Gap Element (AGE)** boundaries are boundary formats 6
+  (periodic AGE) and 7 (antiperiodic AGE). They describe the annular interface
+  between independently positioned inner and outer meshes. AGE data includes
+  the two angular positions, radii, centre, discretization, node references,
+  and interpolation weights needed to couple the rings.
+- The magnetic mesher writes AGE records as an optional extension after the
+  periodic-node-pair section of `.pbc`. Consequently, a valid periodic `.pbc`
+  can contain node pairs and zero AGE records. Do not treat the presence of a
+  `.pbc` file as proof that a sliding air-gap interface exists.
+- In the sliding-mesh workflow, changing the AGE inner/outer angular position
+  represents rotor/stator relative motion while the interpolation data couples
+  the meshes across the annulus. Keep this mesh coupling data separate from
+  solved quantities such as magnetic vector potential or air-gap flux-density
+  harmonics.
+- At mesh-transfer boundaries, preserve zero-based node references and the
+  periodic/antiperiodic type for both ordinary constraints and AGE data. When
+  reading or writing `.pbc`, process the ordinary constraint count and records
+  first, followed by the AGE count and optional AGE records.
+
 ### Lua Scripts
 
 - User-definable FEMM commands via Lua syntax

--- a/cfemm/fmesher/TriangleMesherBackend.cpp
+++ b/cfemm/fmesher/TriangleMesherBackend.cpp
@@ -7,7 +7,6 @@
 #include <iomanip>
 #include <sstream>
 
-using femm::mesh::InvalidPropertyIndex;
 namespace fmesher {
 namespace {
 std::string root(const std::string &p) { auto n=p.find_last_of('.'); return n==std::string::npos?p:p.substr(0,n); }
@@ -18,13 +17,13 @@ bool readLegacy(const std::string &path, const femm::FemmProblem &problem, femm:
  const auto base=root(path); std::ifstream f(base+".node"); size_t count; int dim,attrs,markers;
  if(!(f>>count>>dim>>attrs>>markers)) return false;
  const double scale=femm::LengthConvMeters[problem.LengthUnits];
- out.nodes.resize(count); for(size_t q=0;q<count;q++){size_t id;int marker; f>>id>>out.nodes[id].x>>out.nodes[id].y>>marker; out.nodes[id].x*=scale;out.nodes[id].y*=scale;if(marker>1)out.nodes[id].pointProperty=size_t(marker-2);}
+ out.nodes.resize(count); for(size_t q=0;q<count;q++){size_t id;int marker; f>>id>>out.nodes[id].x>>out.nodes[id].y>>marker; out.nodes[id].x*=scale;out.nodes[id].y*=scale;out.nodes[id].boundaryMarker=marker;}
  f.close(); f.open(base+".ele"); int corners; if(!(f>>count>>corners>>attrs))return false; out.elements.resize(count);
- for(size_t q=0;q<count;q++){size_t id;double region;f>>id>>out.elements[id].nodes[0]>>out.elements[id].nodes[1]>>out.elements[id].nodes[2]>>region;if(region>=1)out.elements[id].blockLabel=size_t(region-1);}
- f.close();f.open(base+".edge");if(!(f>>count>>markers))return false;out.boundaryEdges.resize(count);
- for(size_t q=0;q<count;q++){size_t id;int marker;f>>id>>out.boundaryEdges[id].first>>out.boundaryEdges[id].second>>marker;if(marker<=-2)out.boundaryEdges[id].boundaryProperty=size_t(-marker-2);}
- f.close();f.open(base+".pbc");if(!(f>>count))return false;out.periodicNodePairs.resize(count);
- for(size_t q=0;q<count;q++){size_t id;int anti;f>>id>>out.periodicNodePairs[id].first>>out.periodicNodePairs[id].second>>anti;out.periodicNodePairs[id].periodicity=anti?femm::mesh::SolverMesh::Periodicity::Antiperiodic:femm::mesh::SolverMesh::Periodicity::Periodic;}
+ for(size_t q=0;q<count;q++){size_t id;int region;f>>id>>out.elements[id].nodes[0]>>out.elements[id].nodes[1]>>out.elements[id].nodes[2]>>region;out.elements[id].regionAttribute=region;}
+ f.close();f.open(base+".edge");if(!(f>>count>>markers))return false;out.edges.resize(count);
+ for(size_t q=0;q<count;q++){size_t id;int marker;f>>id>>out.edges[id].first>>out.edges[id].second>>marker;out.edges[id].boundaryMarker=marker;}
+ f.close();f.open(base+".pbc");if(!(f>>count))return false;out.periodicConstraints.resize(count);
+ for(size_t q=0;q<count;q++){size_t id;int anti;f>>id>>out.periodicConstraints[id].first>>out.periodicConstraints[id].second>>anti;out.periodicConstraints[id].periodicity=anti?femm::mesh::SolverMesh::Periodicity::Antiperiodic:femm::mesh::SolverMesh::Periodicity::Periodic;}
  size_t gaps=0;if(!(f>>gaps))return false;out.airGaps.reserve(gaps);
  for(size_t g=0;g<gaps;g++){femm::mesh::SolverMesh::AirGap a; f>>std::quoted(a.boundaryName);int anti;size_t n;f>>anti>>a.innerAngleDegrees>>a.outerAngleDegrees>>a.innerRadius>>a.outerRadius>>a.totalArcLengthDegrees>>a.centerX>>a.centerY>>n>>a.innerShift>>a.outerShift;a.periodicity=anti?femm::mesh::SolverMesh::Periodicity::Antiperiodic:femm::mesh::SolverMesh::Periodicity::Periodic;a.totalArcElements=n;a.innerRadius*=scale;a.outerRadius*=scale;a.centerX*=scale;a.centerY*=scale;a.quadraturePoints.resize(n+1);for(auto &qp:a.quadraturePoints)for(int k=0;k<4;k++)f>>qp.nodes[k]>>qp.weights[k];out.airGaps.push_back(std::move(a));}
  return bool(f);
@@ -36,10 +35,10 @@ femm::mesh::MeshResult TriangleMesherBackend::mesh(femm::FemmProblem &problem,bo
 }
 
 bool SolverMeshFileWriter::write(const femm::mesh::SolverMesh &m,const femm::FemmProblem &p,const std::string &path,int(*warn)(const char*,...)){
- auto base=root(path);const double inv=1.0/femm::LengthConvMeters[p.LengthUnits];std::ofstream f(base+".node");if(!f)return false;f<<m.nodes.size()<<"\t2\t0\t1\n"<<std::setprecision(17);for(size_t i=0;i<m.nodes.size();i++)f<<i<<'\t'<<m.nodes[i].x*inv<<'\t'<<m.nodes[i].y*inv<<'\t'<<(m.nodes[i].pointProperty==InvalidPropertyIndex?0:int(m.nodes[i].pointProperty+2))<<'\n';
- f.close();f.open(base+".edge");if(!f)return false;f<<m.boundaryEdges.size()<<"\t1\n";for(size_t i=0;i<m.boundaryEdges.size();i++)f<<i<<'\t'<<m.boundaryEdges[i].first<<'\t'<<m.boundaryEdges[i].second<<'\t'<<(m.boundaryEdges[i].boundaryProperty==InvalidPropertyIndex?0:-int(m.boundaryEdges[i].boundaryProperty+2))<<'\n';
- f.close();f.open(base+".ele");if(!f)return false;f<<m.elements.size()<<"\t3\t1\n";for(size_t i=0;i<m.elements.size();i++)f<<i<<'\t'<<m.elements[i].nodes[0]<<'\t'<<m.elements[i].nodes[1]<<'\t'<<m.elements[i].nodes[2]<<'\t'<<(m.elements[i].blockLabel==InvalidPropertyIndex?0:m.elements[i].blockLabel+1)<<'\n';
- f.close();f.open(base+".pbc");if(!f)return false;f<<m.periodicNodePairs.size()<<'\n';for(size_t i=0;i<m.periodicNodePairs.size();i++)f<<i<<' '<<m.periodicNodePairs[i].first<<' '<<m.periodicNodePairs[i].second<<' '<<(m.periodicNodePairs[i].periodicity==femm::mesh::SolverMesh::Periodicity::Antiperiodic)<<'\n';f<<m.airGaps.size()<<'\n';for(const auto&a:m.airGaps){f<<std::quoted(a.boundaryName)<<'\n'<<(a.periodicity==femm::mesh::SolverMesh::Periodicity::Antiperiodic)<<' '<<a.innerAngleDegrees<<' '<<a.outerAngleDegrees<<' '<<a.innerRadius*inv<<' '<<a.outerRadius*inv<<' '<<a.totalArcLengthDegrees<<' '<<a.centerX*inv<<' '<<a.centerY*inv<<' '<<a.totalArcElements<<' '<<a.innerShift<<' '<<a.outerShift<<'\n';for(const auto&q:a.quadraturePoints){for(int k=0;k<4;k++)f<<q.nodes[k]<<' '<<q.weights[k]<<(k==3?'\n':' ');}}if(!f&&warn)warn("Couldn't write mesh files");return bool(f);
+ auto base=root(path);const double inv=1.0/femm::LengthConvMeters[p.LengthUnits];std::ofstream f(base+".node");if(!f)return false;f<<m.nodes.size()<<"\t2\t0\t1\n"<<std::setprecision(17);for(size_t i=0;i<m.nodes.size();i++)f<<i<<'\t'<<m.nodes[i].x*inv<<'\t'<<m.nodes[i].y*inv<<'\t'<<m.nodes[i].boundaryMarker<<'\n';
+ f.close();f.open(base+".edge");if(!f)return false;f<<m.edges.size()<<"\t1\n";for(size_t i=0;i<m.edges.size();i++)f<<i<<'\t'<<m.edges[i].first<<'\t'<<m.edges[i].second<<'\t'<<m.edges[i].boundaryMarker<<'\n';
+ f.close();f.open(base+".ele");if(!f)return false;f<<m.elements.size()<<"\t3\t1\n";for(size_t i=0;i<m.elements.size();i++)f<<i<<'\t'<<m.elements[i].nodes[0]<<'\t'<<m.elements[i].nodes[1]<<'\t'<<m.elements[i].nodes[2]<<'\t'<<m.elements[i].regionAttribute<<'\n';
+ f.close();f.open(base+".pbc");if(!f)return false;f<<m.periodicConstraints.size()<<'\n';for(size_t i=0;i<m.periodicConstraints.size();i++)f<<i<<' '<<m.periodicConstraints[i].first<<' '<<m.periodicConstraints[i].second<<' '<<(m.periodicConstraints[i].periodicity==femm::mesh::SolverMesh::Periodicity::Antiperiodic)<<'\n';f<<m.airGaps.size()<<'\n';for(const auto&a:m.airGaps){f<<std::quoted(a.boundaryName)<<'\n'<<(a.periodicity==femm::mesh::SolverMesh::Periodicity::Antiperiodic)<<' '<<a.innerAngleDegrees<<' '<<a.outerAngleDegrees<<' '<<a.innerRadius*inv<<' '<<a.outerRadius*inv<<' '<<a.totalArcLengthDegrees<<' '<<a.centerX*inv<<' '<<a.centerY*inv<<' '<<a.totalArcElements<<' '<<a.innerShift<<' '<<a.outerShift<<'\n';for(const auto&q:a.quadraturePoints){for(int k=0;k<4;k++)f<<q.nodes[k]<<' '<<q.weights[k]<<(k==3?'\n':' ');}}if(!f&&warn)warn("Couldn't write mesh files");return bool(f);
 }
 }
 

--- a/cfemm/fmesher/test/backend_test.cpp
+++ b/cfemm/fmesher/test/backend_test.cpp
@@ -4,6 +4,7 @@
 #include "FemmReader.h"
 #include <iostream>
 #include <cstdio>
+#include <cstdint>
 #include <memory>
 
 int main(int argc, char **argv)
@@ -16,7 +17,19 @@ int main(int argc, char **argv)
     std::unique_ptr<fmesher::MesherBackend> backend(new fmesher::TriangleMesherBackend);
     femm::mesh::MeshingOptions options;
     const auto result = backend->mesh(*facade.problem, false, options);
+    const auto periodicResult = backend->mesh(*facade.problem, true, options);
+    femm::mesh::SolverMesh::Node markerProbe;
+    markerProbe.boundaryMarker = 7;
+    // Marker decoding belongs to the solver consumer, not SolverMesh.
+    const std::int32_t pointProperty = markerProbe.boundaryMarker > 1
+            ? markerProbe.boundaryMarker - 2 : -1;
     std::remove("xfemm-backend.node"); std::remove("xfemm-backend.edge");
     std::remove("xfemm-backend.ele"); std::remove("xfemm-backend.pbc");
-    return result.succeeded() && !result.mesh.nodes.empty() && !result.mesh.elements.empty() ? 0 : 1;
+    return result.succeeded() && !result.mesh.nodes.empty()
+            && !result.mesh.elements.empty()
+            && result.mesh.elements.front().regionAttribute > 0
+            && periodicResult.succeeded()
+            && !periodicResult.mesh.periodicConstraints.empty()
+            && periodicResult.mesh.airGaps.empty()
+            && pointProperty == 5 ? 0 : 1;
 }

--- a/cfemm/libfemm/mesh/SolverMesh.h
+++ b/cfemm/libfemm/mesh/SolverMesh.h
@@ -4,50 +4,60 @@
 #include "RawMesh.h"
 
 #include <array>
+#include <cstdint>
 #include <string>
 #include <vector>
 
 namespace femm {
 namespace mesh {
 
-/** Marker/property index after decoding. Property indices are zero-based. */
-using PropertyIndex = std::size_t;
-
-/** Invalid value for every PropertyIndex field. It denotes "no property". */
-constexpr PropertyIndex InvalidPropertyIndex = std::numeric_limits<PropertyIndex>::max();
-
 /**
- * Mesh ready to be consumed by a FEMM solver.
+ * Value-based mesh transferred from a mesher to a FEMM solver.
  *
  * Coordinates, radii, and centres are expressed in metres, regardless of the
- * length unit used in the source problem. Angles are expressed in degrees.
+ * length unit used in the source problem. Angles are expressed in degrees. The
+ * collections own all of their data and contain no solver solution state.
+ *
+ * Invariants:
+ * - MeshIndex values are zero-based indices into `nodes`.
+ * - Every Element has exactly three nodes and all node references are valid.
+ * - Element region attributes are the raw Triangle attributes corresponding to
+ *   solver block labels (Triangle writes block-label index + 1).
+ * - Node and edge boundary markers retain Triangle's raw signed values. Marker
+ *   decoding therefore remains an explicit operation at the consumer, e.g.
+ *   `marker > 1 ? marker - 2 : -1` for a node point-property marker.
  */
 struct SolverMesh {
     struct Node {
         double x = 0.0; ///< x coordinate in metres.
         double y = 0.0; ///< y coordinate in metres.
-        /** Zero-based point-property index, or InvalidPropertyIndex. */
-        PropertyIndex pointProperty = InvalidPropertyIndex;
+        /** Raw Triangle boundary marker; deliberately not a property index. */
+        std::int32_t boundaryMarker = 0;
     };
 
     struct Element {
         /** Zero-based indices into SolverMesh::nodes; InvalidMeshIndex means unset. */
         std::array<MeshIndex, 3> nodes{{InvalidMeshIndex, InvalidMeshIndex, InvalidMeshIndex}};
-        /** Validated zero-based index into the problem's block-label list. */
-        PropertyIndex blockLabel = InvalidPropertyIndex;
+        /** Raw Triangle region attribute (normally one-based block-label id). */
+        std::int32_t regionAttribute = 0;
     };
 
-    struct BoundaryEdge {
+    struct Edge {
         /** Zero-based indices into SolverMesh::nodes; InvalidMeshIndex means unset. */
         MeshIndex first = InvalidMeshIndex;
         MeshIndex second = InvalidMeshIndex;
-        /** Zero-based boundary-property index, or InvalidPropertyIndex. */
-        PropertyIndex boundaryProperty = InvalidPropertyIndex;
+        /** Raw Triangle boundary marker; deliberately not a property index. */
+        std::int32_t boundaryMarker = 0;
     };
 
     enum class Periodicity { Periodic, Antiperiodic };
 
-    struct PeriodicNodePair {
+    /**
+     * One node equivalence written in the primary section of a `.pbc` file.
+     * These constraints are used by every periodic or antiperiodic model; they
+     * are not specific to air-gap elements.
+     */
+    struct PeriodicConstraint {
         /** Zero-based indices into SolverMesh::nodes; InvalidMeshIndex means unset. */
         MeshIndex first = InvalidMeshIndex;
         MeshIndex second = InvalidMeshIndex;
@@ -62,7 +72,14 @@ struct SolverMesh {
         std::array<double, 4> weights{{0.0, 0.0, 0.0, 0.0}};
     };
 
-    /** Value-only data sufficient to construct and populate CAirGapElement. */
+    /**
+     * Optional value-only air-gap data represented by the magnetic air-gap
+     * extension following the periodic constraints in a `.pbc` file. A `.pbc`
+     * file is not, in general, an air-gap file: periodic models without an air
+     * gap have periodicConstraints and an empty airGaps collection.
+     *
+     * This is mesh topology/interpolation data, not a solver field quantity.
+     */
     struct AirGap {
         std::string boundaryName;
         Periodicity periodicity = Periodicity::Periodic;
@@ -83,8 +100,10 @@ struct SolverMesh {
 
     std::vector<Node> nodes;
     std::vector<Element> elements;
-    std::vector<BoundaryEdge> boundaryEdges;
-    std::vector<PeriodicNodePair> periodicNodePairs;
+    std::vector<Edge> edges;
+    /** Primary `.pbc` node-pair section, applicable to all periodic models. */
+    std::vector<PeriodicConstraint> periodicConstraints;
+    /** Optional magnetic air-gap extension of `.pbc`. */
     std::vector<AirGap> airGaps;
 };
 


### PR DESCRIPTION
### Motivation

- Decouple mesher-produced raw Triangle markers/region attributes from solver property indices so marker decoding is an explicit consumer responsibility.
- Ensure complete transport of periodic constraints and optional magnetic air-gap (AGE) interpolation data from the mesher to the solver.
- Simplify and clarify mesh value semantics so the mesh object contains only topology/interpolation data and no solver state.
- Document the `.pbc` format, AGE semantics, and sliding-mesh considerations in `AGENTS.md`.

### Description

- Rework `SolverMesh` to use explicit raw fields: `Node::boundaryMarker`, `Element::regionAttribute`, `Edge::boundaryMarker`, `PeriodicConstraint`, and preserve `airGaps` as interpolation-only data.
- Remove the `PropertyIndex`/`InvalidPropertyIndex` alias and replace previous property-encoding fields with `std::int32_t` raw markers/attributes and accompanying invariants and comments.
- Update `TriangleMesherBackend::readLegacy` and `SolverMeshFileWriter::write` to read/write `.node`, `.edge`, `.ele`, and `.pbc` using the new raw fields and to preserve AGE records after the primary `.pbc` section.
- Update `cfemm/fmesher/test/backend_test.cpp` to exercise the non-periodic and periodic workflows, to check `regionAttribute` and `periodicConstraints`/`airGaps`, and to demonstrate marker decoding logic.
- Add an explanatory section to `AGENTS.md` describing `.pbc` semantics, the difference between ordinary periodic constraints and AGE boundaries, and guidance for consumers about marker decoding and mesh-transfer semantics.

### Testing

- Built the mesher components and ran the backend integration test `cfemm/fmesher/test/backend_test`, which succeeded.
- Verified that the periodic workflow returns a mesh with non-empty `periodicConstraints` and preserved empty `airGaps` for non-AGE cases.
- Confirmed that `elements.front().regionAttribute` is populated from Triangle output and that marker decoding can be performed by the consumer code.
- No automated tests failed during this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a669eb167248326a295b3d938b288b9)