### PR TITLE
Add AnalysisSession abstraction, backend interface, docs, and unit tests

### DIFF
--- a/cfemm/fsolver/ANALYSIS_SESSION.md
+++ b/cfemm/fsolver/ANALYSIS_SESSION.md
@@ -1,0 +1,50 @@
+# High-level magnetic analysis sessions
+
+`AnalysisSession` is the authority for a user-visible magnetic analysis. It
+separates three kinds of data which legacy solver structures combine:
+
+* `ModelDefinition` owns geometry, labels, materials, boundary and magnetic
+  circuit-port definitions, and structural analysis settings.
+* `SolveParameters` owns values that can vary between evaluations: circuit
+  constraints, frequency, time, air-gap position, and an optional accepted
+  state.
+* `PreparedAnalysis` is disposable solver input derived from the other two.
+
+The session exposes the model as const data. Callers change it through named
+operations such as `setMaterialProperty`; circuit inputs, frequency, and AGE
+positions likewise have named operations. Each operation invalidates the
+smallest reusable layer that can safely be retained. `solve()` always calls
+`synchronize()` before invoking its backend, while explicit synchronization is
+available to separate preparation failures and timing from the solve itself.
+
+## Magnetic circuit ports and future transient coupling
+
+A model circuit is an electromagnetic port, not an instantaneous source and
+not an entire external electrical network. Per-evaluation constraints can be
+prescribed current, prescribed voltage, open circuit, or a coupled unknown.
+`setCircuitCurrent` remains a convenience API; backends receive the complete
+set of port constraints so an external or future XFEMM-managed circuit solver
+can perform coupled iterations.
+
+Solutions are trials. Calling `solve()` does not advance time history.
+`acceptSolution()` explicitly converts a current trial into an immutable
+`AcceptedState`, and rejects trials made obsolete by subsequent model or input
+changes. This permits several current/position guesses at one time point and
+supports step rejection by a future time integrator. Flux linkage is a
+first-class port result; transient induced voltage must be calculated by the
+coupled integration scheme rather than by applying the harmonic `2*pi*f` rule.
+
+## Derived transformations
+
+Series winding expansion is prepared state. The session creates one
+`PreparedCircuit` mapping per winding label, including its signed turn count,
+but never rewrites model circuit definitions or label circuit references.
+Changing its source circuit, labels, turns, or constraint recreates that
+mapping. Material slope data and positioned air-gap coupling are handled the
+same way: they are recreated from authoritative inputs and are never copied
+back into `FemmProblem`.
+
+Concrete solvers implement `AnalysisSolverBackend`. The boundary deliberately
+uses const model, parameter, and prepared views; a backend can retain private
+mesh, matrix, and nonlinear work state, but cannot turn those objects into
+user-visible authority.

--- a/cfemm/fsolver/AnalysisSession.cpp
+++ b/cfemm/fsolver/AnalysisSession.cpp
@@ -1,0 +1,368 @@
+#include "AnalysisSession.h"
+
+#include "CBoundaryProp.h"
+#include "CBlockLabel.h"
+#include "CCircuit.h"
+#include "CMaterialProp.h"
+
+#include <cmath>
+#include <atomic>
+#include <stdexcept>
+
+namespace femm {
+namespace {
+
+std::atomic<std::uint64_t> nextSessionId{1};
+
+std::uint32_t bits(Dirty value) { return static_cast<std::uint32_t>(value); }
+bool has(Dirty value, Dirty flag) { return bits(value & flag) != 0; }
+
+bool sameComplex(const CComplex &lhs, const CComplex &rhs)
+{
+    return lhs.re == rhs.re && lhs.im == rhs.im;
+}
+
+bool sameConstraints(const std::map<CircuitId, CircuitConstraint> &lhs,
+                     const std::map<CircuitId, CircuitConstraint> &rhs)
+{
+    if (lhs.size() != rhs.size())
+        return false;
+    auto lit = lhs.begin();
+    auto rit = rhs.begin();
+    for (; lit != lhs.end(); ++lit, ++rit) {
+        if (!(lit->first == rit->first) || lit->second.kind != rit->second.kind ||
+            !sameComplex(lit->second.value, rit->second.value))
+            return false;
+    }
+    return true;
+}
+
+bool sameAirGaps(const std::map<AirGapId, AirGapPosition> &lhs,
+                 const std::map<AirGapId, AirGapPosition> &rhs)
+{
+    if (lhs.size() != rhs.size())
+        return false;
+    auto lit = lhs.begin();
+    auto rit = rhs.begin();
+    for (; lit != lhs.end(); ++lit, ++rit) {
+        if (lit->first.value != rit->first.value ||
+            lit->second.innerAngle != rit->second.innerAngle ||
+            lit->second.outerAngle != rit->second.outerAngle)
+            return false;
+    }
+    return true;
+}
+
+template<typename T>
+const T &as(const MaterialPropertyValue &value, const char *description)
+{
+    const auto *typed = std::get_if<T>(&value);
+    if (!typed)
+        throw std::invalid_argument(std::string("wrong value type for ") + description);
+    return *typed;
+}
+
+} // namespace
+
+Dirty operator|(Dirty lhs, Dirty rhs)
+{
+    return static_cast<Dirty>(bits(lhs) | bits(rhs));
+}
+
+Dirty operator&(Dirty lhs, Dirty rhs)
+{
+    return static_cast<Dirty>(bits(lhs) & bits(rhs));
+}
+
+ModelDefinition::ModelDefinition(std::unique_ptr<FemmProblem> problem)
+    : m_problem(std::move(problem))
+{
+    if (!m_problem || m_problem->filetype != FileType::MagneticsFile)
+        throw std::invalid_argument("ModelDefinition requires a magnetic FemmProblem");
+    m_problem->updateBlockMap();
+    m_problem->updateCircuitMap();
+    m_problem->updateLineMap();
+}
+
+CircuitId ModelDefinition::circuit(const std::string &name) const
+{
+    const auto found = m_problem->circuitMap.find(name);
+    if (found == m_problem->circuitMap.end())
+        throw std::out_of_range("unknown circuit: " + name);
+    return {static_cast<std::size_t>(found->second)};
+}
+
+MaterialId ModelDefinition::material(const std::string &name) const
+{
+    const auto found = m_problem->blockMap.find(name);
+    if (found == m_problem->blockMap.end())
+        throw std::out_of_range("unknown material: " + name);
+    return {static_cast<std::size_t>(found->second)};
+}
+
+AirGapId ModelDefinition::airGap(const std::string &name) const
+{
+    const auto found = m_problem->lineMap.find(name);
+    if (found == m_problem->lineMap.end())
+        throw std::out_of_range("unknown boundary: " + name);
+    const auto id = static_cast<std::size_t>(found->second);
+    const auto *boundary = dynamic_cast<const CMBoundaryProp *>(m_problem->lineproplist[id].get());
+    if (!boundary || (boundary->BdryFormat != 6 && boundary->BdryFormat != 7))
+        throw std::invalid_argument("boundary is not an air-gap element: " + name);
+    return {id};
+}
+
+AnalysisSession::AnalysisSession(ModelDefinition model, std::shared_ptr<AnalysisSolverBackend> backend)
+    : m_model(std::move(model)), m_backend(std::move(backend)),
+      m_sessionId(nextSessionId.fetch_add(1))
+{
+    if (!m_backend)
+        throw std::invalid_argument("AnalysisSession requires a solver backend");
+    m_parameters.frequency = m_model.problem().Frequency;
+
+    for (std::size_t i = 0; i < m_model.problem().circproplist.size(); ++i) {
+        const auto *circuit = dynamic_cast<const CMCircuit *>(m_model.problem().circproplist[i].get());
+        if (!circuit)
+            throw std::invalid_argument("magnetic model contains a non-magnetic circuit");
+        m_parameters.circuitConstraints[{i}] = {CircuitConstraintKind::PrescribedCurrent,
+                                                circuit->Amps};
+    }
+    for (std::size_t i = 0; i < m_model.problem().lineproplist.size(); ++i) {
+        const auto *boundary = dynamic_cast<const CMBoundaryProp *>(m_model.problem().lineproplist[i].get());
+        if (boundary && (boundary->BdryFormat == 6 || boundary->BdryFormat == 7))
+            m_parameters.airGapPositions[{i}] = {boundary->InnerAngle, boundary->OuterAngle};
+    }
+}
+
+void AnalysisSession::requireCircuit(CircuitId id) const
+{
+    if (id.value >= m_model.problem().circproplist.size())
+        throw std::out_of_range("invalid circuit id");
+}
+
+void AnalysisSession::requireAirGap(AirGapId id) const
+{
+    if (id.value >= m_model.problem().lineproplist.size())
+        throw std::out_of_range("invalid air-gap id");
+    const auto *boundary = dynamic_cast<const CMBoundaryProp *>(m_model.problem().lineproplist[id.value].get());
+    if (!boundary || (boundary->BdryFormat != 6 && boundary->BdryFormat != 7))
+        throw std::invalid_argument("boundary id does not identify an air-gap element");
+}
+
+void AnalysisSession::invalidate(Dirty dirty)
+{
+    m_dirty = m_dirty | dirty | Dirty::SolveState;
+}
+
+void AnalysisSession::setCircuitCurrent(CircuitId id, CComplex value)
+{
+    requireCircuit(id);
+    m_parameters.circuitConstraints[id] = {CircuitConstraintKind::PrescribedCurrent, value};
+    ++m_parameterRevision;
+    invalidate(Dirty::RightHandSide);
+}
+
+void AnalysisSession::setCircuitVoltage(CircuitId id, CComplex value)
+{
+    requireCircuit(id);
+    m_parameters.circuitConstraints[id] = {CircuitConstraintKind::PrescribedVoltage, value};
+    ++m_parameterRevision;
+    invalidate(Dirty::RightHandSide | Dirty::Operator);
+}
+
+void AnalysisSession::setCircuitOpen(CircuitId id)
+{
+    requireCircuit(id);
+    m_parameters.circuitConstraints[id] = {CircuitConstraintKind::OpenCircuit, {}};
+    ++m_parameterRevision;
+    invalidate(Dirty::RightHandSide | Dirty::Operator);
+}
+
+void AnalysisSession::setCircuitCoupled(CircuitId id)
+{
+    requireCircuit(id);
+    m_parameters.circuitConstraints[id] = {CircuitConstraintKind::CoupledUnknown, {}};
+    ++m_parameterRevision;
+    invalidate(Dirty::RightHandSide | Dirty::Operator);
+}
+
+void AnalysisSession::setAirGapAngle(AirGapId id, double inner, double outer)
+{
+    requireAirGap(id);
+    if (!std::isfinite(inner) || !std::isfinite(outer))
+        throw std::invalid_argument("air-gap angles must be finite");
+    m_parameters.airGapPositions[id] = {inner, outer};
+    ++m_parameterRevision;
+    invalidate(Dirty::AirGapCoupling | Dirty::Operator);
+}
+
+void AnalysisSession::setFrequency(double frequency)
+{
+    if (!std::isfinite(frequency) || frequency < 0)
+        throw std::invalid_argument("frequency must be finite and nonnegative");
+    m_parameters.frequency = frequency;
+    ++m_parameterRevision;
+    invalidate(Dirty::PreparedMaterials | Dirty::Operator | Dirty::RightHandSide);
+}
+
+void AnalysisSession::setTime(double time)
+{
+    if (!std::isfinite(time))
+        throw std::invalid_argument("time must be finite");
+    m_parameters.time = time;
+    ++m_parameterRevision;
+    invalidate(Dirty::SolveState);
+}
+
+void AnalysisSession::setInitialState(std::shared_ptr<const AcceptedState> state)
+{
+    if (state && state->modelRevision != m_modelRevision)
+        throw std::invalid_argument("initial solution belongs to another model revision");
+    m_parameters.initialState = std::move(state);
+    ++m_parameterRevision;
+    invalidate(Dirty::InitialState);
+}
+
+void AnalysisSession::setMaterialProperty(MaterialId id, MaterialProperty property,
+                                          const MaterialPropertyValue &value)
+{
+    if (id.value >= m_model.m_problem->blockproplist.size())
+        throw std::out_of_range("invalid material id");
+    auto *material = dynamic_cast<CMMaterialProp *>(m_model.m_problem->blockproplist[id.value].get());
+    if (!material)
+        throw std::invalid_argument("material id does not identify a magnetic material");
+
+    switch (property) {
+    case MaterialProperty::RelativePermeabilityX: material->mu_x = as<double>(value, "mu_x"); break;
+    case MaterialProperty::RelativePermeabilityY: material->mu_y = as<double>(value, "mu_y"); break;
+    case MaterialProperty::Coercivity: material->H_c = as<double>(value, "coercivity"); break;
+    case MaterialProperty::Conductivity: material->Cduct = as<double>(value, "conductivity"); break;
+    case MaterialProperty::LaminationType: material->LamType = as<int>(value, "lamination type"); break;
+    case MaterialProperty::LaminationFill: material->LamFill = as<double>(value, "lamination fill"); break;
+    case MaterialProperty::LaminationThickness: material->Lam_d = as<double>(value, "lamination thickness"); break;
+    case MaterialProperty::AppliedCurrentDensity: material->J = as<CComplex>(value, "current density"); break;
+    case MaterialProperty::BHCurve: {
+        const auto &curve = as<BHCurve>(value, "B-H curve");
+        if (curve.fluxDensity.size() != curve.fieldStrength.size())
+            throw std::invalid_argument("B-H curve arrays must have equal length");
+        material->Bdata = curve.fluxDensity;
+        material->Hdata = curve.fieldStrength;
+        material->BHpoints = static_cast<int>(curve.fluxDensity.size());
+        material->clearSlopes();
+        break;
+    }
+    }
+    ++m_modelRevision;
+    invalidate(Dirty::PreparedMaterials | Dirty::Operator);
+}
+
+void AnalysisSession::updateSolveParameters(const std::function<void(SolveParameters &)> &update)
+{
+    SolveParameters candidate = m_parameters;
+    update(candidate);
+    if (!std::isfinite(candidate.frequency) || candidate.frequency < 0 || !std::isfinite(candidate.time))
+        throw std::invalid_argument("invalid frequency or time in solve parameter update");
+    for (const auto &entry : candidate.circuitConstraints)
+        requireCircuit(entry.first);
+    for (const auto &entry : candidate.airGapPositions) {
+        requireAirGap(entry.first);
+        if (!std::isfinite(entry.second.innerAngle) || !std::isfinite(entry.second.outerAngle))
+            throw std::invalid_argument("air-gap angles must be finite");
+    }
+    if (candidate.initialState && candidate.initialState->modelRevision != m_modelRevision)
+        throw std::invalid_argument("initial solution belongs to another model revision");
+
+    Dirty changed = Dirty::SolveState;
+    if (candidate.frequency != m_parameters.frequency)
+        changed = changed | Dirty::PreparedMaterials | Dirty::Operator | Dirty::RightHandSide;
+    if (!sameConstraints(candidate.circuitConstraints, m_parameters.circuitConstraints))
+        changed = changed | Dirty::RightHandSide | Dirty::Operator;
+    if (!sameAirGaps(candidate.airGapPositions, m_parameters.airGapPositions))
+        changed = changed | Dirty::AirGapCoupling | Dirty::Operator;
+    if (candidate.initialState != m_parameters.initialState)
+        changed = changed | Dirty::InitialState;
+
+    m_parameters = std::move(candidate);
+    ++m_parameterRevision;
+    invalidate(changed);
+}
+
+void AnalysisSession::rebuildMaterials(PreparedAnalysis &candidate) const
+{
+    candidate.materials.clear();
+    candidate.materials.reserve(m_model.problem().blockproplist.size());
+    for (const auto &property : m_model.problem().blockproplist) {
+        const auto *material = dynamic_cast<const CMMaterialProp *>(property.get());
+        if (!material)
+            throw std::invalid_argument("magnetic model contains a non-magnetic material");
+        candidate.materials.emplace_back(*material);
+        auto &prepared = candidate.materials.back();
+        prepared.clearSlopes();
+        if (prepared.BHpoints > 0)
+            prepared.GetSlopes(m_parameters.frequency * 2.0 * 3.14159265358979323846);
+    }
+    candidate.frequency = m_parameters.frequency;
+}
+
+void AnalysisSession::rebuildCircuits(PreparedAnalysis &candidate) const
+{
+    candidate.circuits.clear();
+    for (std::size_t labelIndex = 0; labelIndex < m_model.problem().labellist.size(); ++labelIndex) {
+        const auto *label = dynamic_cast<const CMBlockLabel *>(m_model.problem().labellist[labelIndex].get());
+        if (!label || label->InCircuit < 0)
+            continue;
+        CircuitId id{static_cast<std::size_t>(label->InCircuit)};
+        requireCircuit(id);
+        const auto constraint = m_parameters.circuitConstraints.at(id);
+        candidate.circuits.push_back({id, labelIndex, label->Turns, constraint});
+    }
+}
+
+void AnalysisSession::synchronize()
+{
+    if (m_dirty == Dirty::None || m_dirty == Dirty::SolveState)
+        return;
+
+    PreparedAnalysis candidate = m_prepared;
+    if (has(m_dirty, Dirty::PreparedMaterials))
+        rebuildMaterials(candidate);
+    if (has(m_dirty, Dirty::PreparedCircuits) || has(m_dirty, Dirty::RightHandSide))
+        rebuildCircuits(candidate);
+    if (has(m_dirty, Dirty::AirGapCoupling))
+        candidate.airGapPositions = m_parameters.airGapPositions;
+
+    const Dirty rebuilt = static_cast<Dirty>(bits(m_dirty) & ~bits(Dirty::SolveState));
+    m_backend->synchronize(m_model, m_parameters, candidate, rebuilt);
+    m_prepared = std::move(candidate);
+    m_dirty = Dirty::SolveState;
+}
+
+TrialSolution AnalysisSession::solve()
+{
+    synchronize();
+    TrialSolution result = m_backend->solve(m_model, m_parameters, m_prepared);
+    result.id = m_nextSolutionId++;
+    result.sessionId = m_sessionId;
+    result.modelRevision = m_modelRevision;
+    result.parameterRevision = m_parameterRevision;
+    result.time = m_parameters.time;
+    m_dirty = Dirty::None;
+    return result;
+}
+
+std::shared_ptr<const AcceptedState> AnalysisSession::acceptSolution(const TrialSolution &solution)
+{
+    if (solution.sessionId != m_sessionId || solution.modelRevision != m_modelRevision ||
+        solution.parameterRevision != m_parameterRevision || solution.id == 0)
+        throw std::invalid_argument("trial solution is stale or does not belong to this session");
+    auto accepted = std::make_shared<AcceptedState>(AcceptedState{solution.modelRevision,
+                                                                  solution.parameterRevision,
+                                                                  solution.time,
+                                                                  solution.backendState});
+    m_parameters.initialState = accepted;
+    ++m_parameterRevision;
+    invalidate(Dirty::InitialState);
+    return accepted;
+}
+
+} // namespace femm

--- a/cfemm/fsolver/AnalysisSession.h
+++ b/cfemm/fsolver/AnalysisSession.h
@@ -1,0 +1,209 @@
+#ifndef XFEMM_ANALYSISSESSION_H
+#define XFEMM_ANALYSISSESSION_H
+
+#include "FemmProblem.h"
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace femm {
+
+struct CircuitId {
+    std::size_t value;
+    friend bool operator<(CircuitId a, CircuitId b) { return a.value < b.value; }
+    friend bool operator==(CircuitId a, CircuitId b) { return a.value == b.value; }
+};
+
+struct MaterialId {
+    std::size_t value;
+};
+
+struct AirGapId {
+    std::size_t value;
+    friend bool operator<(AirGapId a, AirGapId b) { return a.value < b.value; }
+};
+
+/** User-authored magnetic model. Mutable access is deliberately limited to AnalysisSession. */
+class ModelDefinition {
+public:
+    /** Transfers exclusive ownership so no caller can bypass session dirty tracking. */
+    explicit ModelDefinition(std::unique_ptr<FemmProblem> problem);
+    const FemmProblem &problem() const { return *m_problem; }
+
+    CircuitId circuit(const std::string &name) const;
+    MaterialId material(const std::string &name) const;
+    AirGapId airGap(const std::string &name) const;
+
+private:
+    friend class AnalysisSession;
+    std::unique_ptr<FemmProblem> m_problem;
+};
+
+enum class CircuitConstraintKind {
+    PrescribedCurrent,
+    PrescribedVoltage,
+    OpenCircuit,
+    CoupledUnknown
+};
+
+struct CircuitConstraint {
+    CircuitConstraintKind kind = CircuitConstraintKind::OpenCircuit;
+    CComplex value;
+};
+
+struct AirGapPosition {
+    double innerAngle = 0;
+    double outerAngle = 0;
+};
+
+struct AcceptedState {
+    std::uint64_t modelRevision = 0;
+    std::uint64_t parameterRevision = 0;
+    double time = 0;
+    std::string backendState;
+};
+
+/** Inputs which may change between evaluations without changing the physical model. */
+struct SolveParameters {
+    double frequency = 0;
+    double time = 0;
+    std::map<CircuitId, CircuitConstraint> circuitConstraints;
+    std::map<AirGapId, AirGapPosition> airGapPositions;
+    std::shared_ptr<const AcceptedState> initialState;
+};
+
+enum class MaterialProperty {
+    RelativePermeabilityX,
+    RelativePermeabilityY,
+    Coercivity,
+    Conductivity,
+    LaminationType,
+    LaminationFill,
+    LaminationThickness,
+    AppliedCurrentDensity,
+    BHCurve
+};
+
+struct BHCurve {
+    std::vector<double> fluxDensity;
+    std::vector<CComplex> fieldStrength;
+};
+
+using MaterialPropertyValue = std::variant<double, int, CComplex, BHCurve>;
+
+enum class Dirty : std::uint32_t {
+    None = 0,
+    ModelIndex = 1u << 0,
+    Mesh = 1u << 1,
+    PreparedMaterials = 1u << 2,
+    PreparedCircuits = 1u << 3,
+    AirGapCoupling = 1u << 4,
+    Operator = 1u << 5,
+    RightHandSide = 1u << 6,
+    InitialState = 1u << 7,
+    SolveState = 1u << 8,
+    All = (1u << 9) - 1
+};
+
+Dirty operator|(Dirty lhs, Dirty rhs);
+Dirty operator&(Dirty lhs, Dirty rhs);
+
+struct PreparedCircuit {
+    CircuitId source;
+    std::size_t labelIndex;
+    int signedTurns;
+    CircuitConstraint constraint;
+};
+
+/** Disposable solver input. It is recreated from authoritative user data. */
+struct PreparedAnalysis {
+    std::vector<CMMaterialProp> materials;
+    std::vector<PreparedCircuit> circuits;
+    std::map<AirGapId, AirGapPosition> airGapPositions;
+    double frequency = 0;
+};
+
+struct CircuitPortResult {
+    CircuitId id;
+    CComplex current;
+    CComplex fluxLinkage;
+    std::optional<CComplex> terminalVoltage;
+};
+
+struct TrialSolution {
+    std::uint64_t id = 0;
+    std::uint64_t sessionId = 0;
+    std::uint64_t modelRevision = 0;
+    std::uint64_t parameterRevision = 0;
+    double time = 0;
+    std::vector<CircuitPortResult> circuits;
+    std::string backendState;
+};
+
+/** Adapter implemented by a concrete field solver; it never receives mutable model state. */
+class AnalysisSolverBackend {
+public:
+    virtual ~AnalysisSolverBackend() = default;
+    virtual void synchronize(const ModelDefinition &model,
+                             const SolveParameters &parameters,
+                             const PreparedAnalysis &prepared,
+                             Dirty rebuilt) = 0;
+    virtual TrialSolution solve(const ModelDefinition &model,
+                                const SolveParameters &parameters,
+                                const PreparedAnalysis &prepared) = 0;
+};
+
+class AnalysisSession {
+public:
+    AnalysisSession(ModelDefinition model, std::shared_ptr<AnalysisSolverBackend> backend);
+
+    const ModelDefinition &model() const { return m_model; }
+    const SolveParameters &solveParameters() const { return m_parameters; }
+    const PreparedAnalysis &prepared() const { return m_prepared; }
+    Dirty dirty() const { return m_dirty; }
+
+    void setCircuitCurrent(CircuitId id, CComplex current);
+    void setCircuitVoltage(CircuitId id, CComplex voltage);
+    void setCircuitOpen(CircuitId id);
+    void setCircuitCoupled(CircuitId id);
+    void setAirGapAngle(AirGapId id, double innerAngle, double outerAngle);
+    void setFrequency(double frequency);
+    void setTime(double time);
+    void setInitialState(std::shared_ptr<const AcceptedState> state);
+    void setMaterialProperty(MaterialId id, MaterialProperty property,
+                             const MaterialPropertyValue &value);
+
+    /** Apply several changes atomically and coalesce their invalidations. */
+    void updateSolveParameters(const std::function<void(SolveParameters &)> &update);
+
+    void synchronize();
+    TrialSolution solve();
+    std::shared_ptr<const AcceptedState> acceptSolution(const TrialSolution &solution);
+
+private:
+    void requireCircuit(CircuitId id) const;
+    void requireAirGap(AirGapId id) const;
+    void invalidate(Dirty dirty);
+    void rebuildMaterials(PreparedAnalysis &candidate) const;
+    void rebuildCircuits(PreparedAnalysis &candidate) const;
+
+    ModelDefinition m_model;
+    SolveParameters m_parameters;
+    PreparedAnalysis m_prepared;
+    std::shared_ptr<AnalysisSolverBackend> m_backend;
+    Dirty m_dirty = Dirty::All;
+    std::uint64_t m_modelRevision = 1;
+    std::uint64_t m_parameterRevision = 1;
+    std::uint64_t m_nextSolutionId = 1;
+    std::uint64_t m_sessionId = 0;
+};
+
+} // namespace femm
+
+#endif

--- a/cfemm/fsolver/CMakeLists.txt
+++ b/cfemm/fsolver/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(fsolver STATIC 
+    AnalysisSession.cpp
     fsolver.cpp
     harmonic2d.cpp
     harmonicaxi.cpp

--- a/cfemm/fsolver/test/CMakeLists.txt
+++ b/cfemm/fsolver/test/CMakeLists.txt
@@ -63,4 +63,9 @@ endfunction()
 
 test_fsolver(Temp TRUE)
 test_fsolver(Temp1 FALSE)
+
+add_executable(analysis_session_test analysis_session_test.cpp)
+target_link_libraries(analysis_session_test PRIVATE fsolver)
+add_test(NAME analysis_session COMMAND analysis_session_test)
+set_tests_properties(analysis_session PROPERTIES LABELS "magnetics;solver;unit")
 # vi:expandtab:tabstop=4 shiftwidth=4:

--- a/cfemm/fsolver/test/analysis_session_test.cpp
+++ b/cfemm/fsolver/test/analysis_session_test.cpp
@@ -1,0 +1,140 @@
+#include "AnalysisSession.h"
+
+#include "CBoundaryProp.h"
+#include "CBlockLabel.h"
+#include "CCircuit.h"
+#include "CMaterialProp.h"
+
+#include <cassert>
+#include <memory>
+#include <stdexcept>
+
+namespace {
+
+class RecordingBackend final : public femm::AnalysisSolverBackend {
+public:
+    void synchronize(const femm::ModelDefinition &, const femm::SolveParameters &,
+                     const femm::PreparedAnalysis &, femm::Dirty rebuilt) override
+    {
+        lastRebuilt = rebuilt;
+        ++synchronizations;
+    }
+
+    femm::TrialSolution solve(const femm::ModelDefinition &,
+                              const femm::SolveParameters &parameters,
+                              const femm::PreparedAnalysis &) override
+    {
+        ++solves;
+        femm::TrialSolution result;
+        result.backendState = "accepted-field-state";
+        for (const auto &entry : parameters.circuitConstraints) {
+            if (entry.second.kind == femm::CircuitConstraintKind::PrescribedCurrent)
+                result.circuits.push_back({entry.first, entry.second.value,
+                                           entry.second.value * 2.0, std::nullopt});
+        }
+        return result;
+    }
+
+    femm::Dirty lastRebuilt = femm::Dirty::None;
+    int synchronizations = 0;
+    int solves = 0;
+};
+
+std::unique_ptr<femm::FemmProblem> makeProblem()
+{
+    auto problem = std::make_unique<femm::FemmProblem>(femm::FileType::MagneticsFile);
+
+    auto material = std::make_unique<femm::CMMaterialProp>();
+    material->BlockName = "steel";
+    material->mu_x = 100;
+    material->mu_y = 100;
+    problem->blockproplist.push_back(std::move(material));
+
+    auto circuit = std::make_unique<femm::CMCircuit>();
+    circuit->CircName = "phase-a";
+    circuit->CircType = 1;
+    circuit->Amps = 3;
+    problem->circproplist.push_back(std::move(circuit));
+
+    auto first = std::make_unique<femm::CMBlockLabel>();
+    first->InCircuit = 0;
+    first->Turns = 10;
+    problem->labellist.push_back(std::move(first));
+    auto second = std::make_unique<femm::CMBlockLabel>();
+    second->InCircuit = 0;
+    second->Turns = -5;
+    problem->labellist.push_back(std::move(second));
+
+    auto gap = std::make_unique<femm::CMBoundaryProp>();
+    gap->BdryName = "rotor-gap";
+    gap->BdryFormat = 6;
+    gap->InnerAngle = 1;
+    gap->OuterAngle = 2;
+    problem->lineproplist.push_back(std::move(gap));
+    return problem;
+}
+
+} // namespace
+
+int main()
+{
+    auto backend = std::make_shared<RecordingBackend>();
+    femm::AnalysisSession session(femm::ModelDefinition(makeProblem()), backend);
+
+    const auto circuit = session.model().circuit("phase-a");
+    const auto material = session.model().material("steel");
+    const auto gap = session.model().airGap("rotor-gap");
+
+    session.synchronize();
+    assert(backend->synchronizations == 1);
+    assert(session.prepared().circuits.size() == 2);
+    assert(session.prepared().circuits[0].signedTurns == 10);
+    assert(session.prepared().circuits[1].signedTurns == -5);
+    // Preparing series windings must not rewrite the authoritative labels or circuit.
+    assert(session.model().problem().labellist[0]->InCircuit == 0);
+    assert(dynamic_cast<const femm::CMCircuit *>(
+               session.model().problem().circproplist[0].get())->CircType == 1);
+
+    session.setCircuitCurrent(circuit, CComplex(7, 0));
+    session.synchronize();
+    assert(backend->synchronizations == 2);
+    assert((session.dirty() & femm::Dirty::SolveState) != femm::Dirty::None);
+    assert(session.prepared().circuits[0].constraint.value == CComplex(7, 0));
+
+    session.setAirGapAngle(gap, 12, 2);
+    session.setFrequency(50);
+    session.setMaterialProperty(material, femm::MaterialProperty::Conductivity, 5.8);
+    session.synchronize();
+    assert(session.prepared().frequency == 50);
+    assert(session.prepared().airGapPositions.at(gap).innerAngle == 12);
+    assert(session.model().problem().Frequency == 0); // not copied to the model.
+
+    const auto trial = session.solve();
+    assert(backend->solves == 1);
+    assert(trial.id != 0);
+    assert(trial.circuits[0].fluxLinkage == CComplex(14, 0));
+    const auto accepted = session.acceptSolution(trial);
+    assert(accepted->backendState == "accepted-field-state");
+    assert(session.solveParameters().initialState == accepted);
+
+    session.setTime(0.01);
+    bool staleRejected = false;
+    try {
+        session.acceptSolution(trial);
+    } catch (const std::invalid_argument &) {
+        staleRejected = true;
+    }
+    assert(staleRejected);
+
+    const auto before = session.solveParameters();
+    bool invalidBatchRejected = false;
+    try {
+        session.updateSolveParameters([](femm::SolveParameters &parameters) {
+            parameters.frequency = -1;
+        });
+    } catch (const std::invalid_argument &) {
+        invalidBatchRejected = true;
+    }
+    assert(invalidBatchRejected);
+    assert(session.solveParameters().frequency == before.frequency);
+}


### PR DESCRIPTION
### Motivation

- Provide a clear user-visible abstraction for magnetic analyses that separates immutable model definition from per-evaluation inputs and disposable prepared solver input. 
- Enable backends to receive const views of authoritative data and to manage their private solver state while supporting circuit-port constraints, air-gap positions, and accepted transient state. 

### Description

- Add `AnalysisSession` implementation and public API in `AnalysisSession.h` / `AnalysisSession.cpp` with `ModelDefinition`, `SolveParameters`, `PreparedAnalysis`, `AcceptedState`, `TrialSolution`, and `Dirty` tracking. 
- Introduce the `AnalysisSolverBackend` interface to decouple concrete solvers from mutable model state and implement session methods such as `setCircuitCurrent`, `setCircuitVoltage`, `setAirGapAngle`, `setFrequency`, `setTime`, `setMaterialProperty`, `synchronize`, `solve`, and `acceptSolution`. 
- Add high-level design documentation in `ANALYSIS_SESSION.md` describing session responsibilities, circuit-port semantics, prepared transformations, and backend constraints. 
- Wire the new sources into build by adding `AnalysisSession.cpp` to `cfemm/fsolver/CMakeLists.txt` and add a unit test target `analysis_session_test` with CMake test registration, and include `analysis_session_test.cpp` exercising core session behaviors and invariants. 

### Testing

- Added an automated unit test `analysis_session` (executable `analysis_session_test`) which runs assertions covering synchronization, prepared circuit/material rebuilding, parameter updates, `solve()` and `acceptSolution()` semantics, and invalid argument rejection. The test passed locally in the test run. 
- Existing `fsolver` test infrastructure and test helper function `test_fsolver(...)` remain unchanged and continue to be available under the `magnetics` label.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a674ffa81fc83268a7bfb4813900f2f)