### PR TITLE
Add immutable magnetic solution snapshots

### DIFF
--- a/cfemm/fpproc/CMakeLists.txt
+++ b/cfemm/fpproc/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(fpproc STATIC
     makemask.cpp
     CMPointVals.cpp
     CPostProcMElement.cpp
+    MagneticSolutionSnapshot.cpp
     )
 target_include_directories(fpproc PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
 target_link_libraries(fpproc PUBLIC femm)
@@ -12,6 +13,20 @@ add_executable(fpproc-test
     )
 
 target_link_libraries(fpproc-test fpproc)
+
+add_executable(fpproc-snapshot-test test/snapshot_parity_test.cpp)
+target_link_libraries(fpproc-snapshot-test PRIVATE fpproc)
+add_test(NAME fpproc_snapshot_parity
+    COMMAND fpproc-snapshot-test ${CMAKE_BINARY_DIR}/fsolver/test/Temp.ans)
+set_tests_properties(fpproc_snapshot_parity PROPERTIES LABELS "magnetics;postprocessor;unit")
+set_tests_properties(fpproc_snapshot_parity PROPERTIES DEPENDS fsolver_Temp.solve)
+
+add_test(NAME fpproc_snapshot_age_parity
+    COMMAND fpproc-snapshot-test
+            ${CMAKE_BINARY_DIR}/femmcli/test/femmcli_antiperiodicBC_AGE_TorqueBenchmark.result.ans)
+set_tests_properties(fpproc_snapshot_age_parity PROPERTIES
+    DEPENDS femmcli_antiperiodicBC_AGE_TorqueBenchmark.lua
+    LABELS "magnetics;postprocessor;unit;airgap")
 install(
     TARGETS fpproc-test
     RUNTIME DESTINATION bin

--- a/cfemm/fpproc/MagneticSolutionSnapshot.cpp
+++ b/cfemm/fpproc/MagneticSolutionSnapshot.cpp
@@ -1,0 +1,42 @@
+#include "MagneticSolutionSnapshot.h"
+
+#include "fpproc.h"
+
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+
+MagneticSolutionSnapshot::MagneticSolutionSnapshot(
+        std::shared_ptr<const FPProc> state,
+        std::shared_ptr<const std::string> ansRepresentation)
+    : m_state(std::move(state)), m_ansRepresentation(std::move(ansRepresentation))
+{
+    if (!m_state)
+        throw std::invalid_argument("a magnetic solution snapshot requires solution state");
+}
+
+MagneticSolutionSnapshot MagneticSolutionSnapshot::fromAnsFile(const std::string &path)
+{
+    std::ifstream input(path, std::ios::binary);
+    if (!input)
+        throw std::runtime_error("could not read magnetic solution file: " + path);
+    auto representation = std::make_shared<const std::string>(
+        std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+
+    auto processor = std::make_shared<FPProc>();
+    if (!processor->OpenDocument(path))
+        throw std::runtime_error("invalid magnetic solution file: " + path);
+    return MagneticSolutionSnapshot(std::move(processor), std::move(representation));
+}
+
+bool MagneticSolutionSnapshot::writeAnsFile(const std::string &path) const
+{
+    if (!m_ansRepresentation)
+        return false;
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    if (!output)
+        return false;
+    output.write(m_ansRepresentation->data(),
+                 static_cast<std::streamsize>(m_ansRepresentation->size()));
+    return output.good();
+}

--- a/cfemm/fpproc/MagneticSolutionSnapshot.h
+++ b/cfemm/fpproc/MagneticSolutionSnapshot.h
@@ -1,0 +1,34 @@
+#ifndef MAGNETICSOLUTIONSNAPSHOT_H
+#define MAGNETICSOLUTIONSNAPSHOT_H
+
+#include <memory>
+#include <string>
+
+class FPProc;
+
+/**
+ * Immutable, in-memory result of a magnetic analysis.
+ *
+ * The snapshot deliberately has no mutating accessors.  FPProc is a view over
+ * a snapshot; .ans files are only persistence adapters used to create or save
+ * one.
+ */
+class MagneticSolutionSnapshot
+{
+public:
+    /** Read the legacy FEMM .ans representation into an immutable snapshot. */
+    static MagneticSolutionSnapshot fromAnsFile(const std::string &path);
+
+    /** Persist the original .ans representation, when this snapshot came from one. */
+    bool writeAnsFile(const std::string &path) const;
+
+private:
+    friend class FPProc;
+    MagneticSolutionSnapshot(std::shared_ptr<const FPProc> state,
+                             std::shared_ptr<const std::string> ansRepresentation = {});
+
+    std::shared_ptr<const FPProc> m_state;
+    std::shared_ptr<const std::string> m_ansRepresentation;
+};
+
+#endif

--- a/cfemm/fpproc/fpproc.cpp
+++ b/cfemm/fpproc/fpproc.cpp
@@ -39,6 +39,7 @@
 #include "lua.h"
 #include "lualib.h"
 #include "fpproc.h"
+#include "MagneticSolutionSnapshot.h"
 
 //#define DEBUG_FPPROC 1
 
@@ -124,6 +125,76 @@ FPProc::FPProc()
     // point to the PrintWarningMsg function
     WarnMessage = &PrintWarningMsg;
 
+}
+
+FPProc::FPProc(const MagneticSolutionSnapshot &snapshot)
+    : FPProc()
+{
+    copySolutionFrom(*snapshot.m_state);
+}
+
+MagneticSolutionSnapshot FPProc::solutionSnapshot() const
+{
+    auto copy = std::make_shared<FPProc>();
+    copy->copySolutionFrom(*this);
+    return MagneticSolutionSnapshot(std::move(copy));
+}
+
+void FPProc::copySolutionFrom(const FPProc &s)
+{
+    ClearDocument();
+    Frequency=s.Frequency; Depth=s.Depth; Precision=s.Precision;
+    LengthUnits=s.LengthUnits; problemType=s.problemType; Coords=s.Coords;
+    ProblemNote=s.ProblemNote; Smooth=s.Smooth;
+    bMultiplyDefinedLabels=s.bMultiplyDefinedLabels; WeightingScheme=s.WeightingScheme;
+    extRo=s.extRo; extRi=s.extRi; extZo=s.extZo; NumAirGapElems=s.NumAirGapElems;
+    PrevSoln=s.PrevSoln; PrevType=s.PrevType; A_High=s.A_High; A_Low=s.A_Low;
+    A_lb=s.A_lb; A_ub=s.A_ub; B_High=s.B_High; B_Low=s.B_Low; H_High=s.H_High;
+    d_LineIntegralPoints=s.d_LineIntegralPoints; d_ShiftH=s.d_ShiftH;
+    bHasMask=false; bIncremental=s.bIncremental;
+    for (int i=0;i<9;++i) for (int j=0;j<2;++j) {
+        PlotBounds[i][j]=s.PlotBounds[i][j]; d_PlotBounds[i][j]=s.d_PlotBounds[i][j];
+    }
+    nodelist=s.nodelist; linelist=s.linelist; arclist=s.arclist; blocklist=s.blocklist;
+    meshnode=s.meshnode; meshelem=s.meshelem;
+    blockproplist=s.blockproplist; lineproplist=s.lineproplist;
+    nodeproplist=s.nodeproplist; circproplist=s.circproplist;
+
+    agelist.reserve(s.agelist.size());
+    for (const auto &from : s.agelist) {
+        CAirGapElement to = from;
+        const auto copyComplex = [](const CComplex *p, int n) {
+            CComplex *q = p ? static_cast<CComplex *>(calloc(n, sizeof(CComplex))) : nullptr;
+            if (q)
+                std::copy(p, p+n, q);
+            return q;
+        };
+        const auto copyDouble = [](const double *p, int n) {
+            double *q = p ? static_cast<double *>(calloc(n, sizeof(double))) : nullptr;
+            if (q)
+                std::copy(p, p+n, q);
+            return q;
+        };
+        to.brc=copyComplex(from.brc,from.nn); to.brs=copyComplex(from.brs,from.nn);
+        to.btc=copyComplex(from.btc,from.nn); to.bts=copyComplex(from.bts,from.nn);
+        to.br=copyComplex(from.br,from.totalArcElements); to.bt=copyComplex(from.bt,from.totalArcElements);
+        to.brcPrev=copyDouble(from.brcPrev,from.nn); to.brsPrev=copyDouble(from.brsPrev,from.nn);
+        to.btcPrev=copyDouble(from.btcPrev,from.nn); to.btsPrev=copyDouble(from.btsPrev,from.nn);
+        to.brPrev=copyDouble(from.brPrev,from.totalArcElements); to.btPrev=copyDouble(from.btPrev,from.totalArcElements);
+        to.nh=from.nh ? static_cast<int *>(calloc(from.nn,sizeof(int))) : nullptr;
+        if (to.nh) std::copy(from.nh,from.nh+from.nn,to.nh);
+        agelist.push_back(to);
+    }
+
+    NumList=static_cast<int *>(calloc(meshnode.size(),sizeof(int)));
+    ConList=static_cast<int **>(calloc(meshnode.size(),sizeof(int *)));
+    for (const auto &e : meshelem) for (int j=0;j<3;++j) ++NumList[e.p[j]];
+    for (std::size_t i=0;i<meshnode.size();++i) ConList[i]=static_cast<int *>(calloc(NumList[i],sizeof(int)));
+    std::vector<int> offsets(meshnode.size());
+    for (std::size_t i=0;i<meshelem.size();++i) for (int j=0;j<3;++j) {
+        const int node=meshelem[i].p[j]; ConList[node][offsets[node]++]=static_cast<int>(i);
+    }
+    pmeshnode=&meshnode; pmeshelem=&meshelem;
 }
 
 /**

--- a/cfemm/fpproc/fpproc.h
+++ b/cfemm/fpproc/fpproc.h
@@ -52,6 +52,8 @@
 
 #include <vector>
 
+class MagneticSolutionSnapshot;
+
 //#ifndef PLANAR
 //#define PLANAR 0
 //#endif
@@ -85,6 +87,8 @@ class FPProc : public femm::PProcIface
 public:
 
     FPProc();
+    /** Initialize a mutable post-processing view directly from an immutable solution. */
+    explicit FPProc(const MagneticSolutionSnapshot &snapshot);
     virtual ~FPProc();
 
     // General problem attributes
@@ -275,6 +279,8 @@ public:
     bool NewDocument();
 //     virtual void Serialize(CArchive& ar);
     bool OpenDocument(std::string lpszPathName) override;
+    /** Freeze the currently loaded solution (selection and contour state are excluded). */
+    MagneticSolutionSnapshot solutionSnapshot() const;
     bool MakeMask();
     //bool LoadMeshNodesFromSolution(bool loadA, FILE* fp);
     //bool LoadMeshElementsFromSolution(FILE* fp);
@@ -287,6 +293,8 @@ public:
     bool luafired;
 
 private:
+
+    void copySolutionFrom(const FPProc &source);
 
     char warnBuf [1028];
 

--- a/cfemm/fpproc/test/snapshot_parity_test.cpp
+++ b/cfemm/fpproc/test/snapshot_parity_test.cpp
@@ -1,0 +1,94 @@
+#include "MagneticSolutionSnapshot.h"
+#include "fpproc.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+#define REQUIRE(condition) do { if (!(condition)) { std::fprintf(stderr, "requirement failed at line %d: %s\n", __LINE__, #condition); std::abort(); } } while (false)
+
+namespace {
+bool close(CComplex a, CComplex b)
+{
+    const auto scalarClose = [](double x, double y) {
+        return (std::isnan(x) && std::isnan(y)) ||
+               std::abs(x-y) <= 1e-11*(1+std::abs(x));
+    };
+    return scalarClose(a.re,b.re) && scalarClose(a.im,b.im);
+}
+}
+
+int main(int argc, char **argv)
+{
+    REQUIRE(argc == 2);
+    FPProc persisted;
+    REQUIRE(persisted.OpenDocument(argv[1]));
+    const auto snapshot = persisted.solutionSnapshot();
+    FPProc memory(snapshot);
+
+    REQUIRE(memory.numNodes() == persisted.numNodes());
+    REQUIRE(memory.numElements() == persisted.numElements());
+    CMPointVals a, b;
+    const auto &element = persisted.meshelem.front();
+    const double x = (persisted.meshnode[element.p[0]].x + persisted.meshnode[element.p[1]].x + persisted.meshnode[element.p[2]].x) / 3.;
+    const double y = (persisted.meshnode[element.p[0]].y + persisted.meshnode[element.p[1]].y + persisted.meshnode[element.p[2]].y) / 3.;
+    REQUIRE(persisted.GetPointValues(x, y, a) == memory.GetPointValues(x, y, b));
+    REQUIRE(close(a.A, b.A)); REQUIRE(close(a.B1, b.B1)); REQUIRE(close(a.B2, b.B2));
+
+    for (std::size_t i=0;i<persisted.blocklist.size();++i) {
+        persisted.blocklist[i].IsSelected=true; memory.blocklist[i].IsSelected=true;
+    }
+    // Includes energy/current/volume, Lorentz and weighted-stress force/torque families.
+    for (int integral=0;integral<=30;++integral) {
+        const CComplex fromFile=persisted.BlockIntegral(integral);
+        const CComplex fromMemory=memory.BlockIntegral(integral);
+        if (!close(fromFile,fromMemory)) {
+            std::fprintf(stderr,"block integral %d differs: (%g,%g) != (%g,%g)\n",
+                         integral,fromFile.re,fromFile.im,fromMemory.re,fromMemory.im);
+            std::abort();
+        }
+    }
+    // The non-AGE fixture supplies a simple interior contour for all line integrals.
+    if (persisted.agelist.empty()) {
+        const auto &n0=persisted.meshnode[element.p[0]];
+        const auto &n1=persisted.meshnode[element.p[1]];
+        persisted.contour={CComplex(.9*x+.1*n0.x,.9*y+.1*n0.y),
+                           CComplex(.9*x+.1*n1.x,.9*y+.1*n1.y)};
+        memory.contour=persisted.contour;
+        for (int integral=0;integral<=5;++integral) {
+            CComplex fromFile[4]{},fromMemory[4]{};
+            persisted.LineIntegral(integral,fromFile);
+            memory.LineIntegral(integral,fromMemory);
+            for (int i=0;i<4;++i)
+                REQUIRE(close(fromFile[i],fromMemory[i]));
+        }
+    }
+    for (std::size_t i=0;i<persisted.circproplist.size();++i) {
+        REQUIRE(close(persisted.GetVoltageDrop(static_cast<int>(i)), memory.GetVoltageDrop(static_cast<int>(i))));
+        REQUIRE(close(persisted.GetFluxLinkage(static_cast<int>(i)), memory.GetFluxLinkage(static_cast<int>(i))));
+    }
+    for (const auto &gap : persisted.agelist) {
+        int na=0, nb=0;
+        REQUIRE(persisted.numGapHarmonics(gap.BdryName,na)==memory.numGapHarmonics(gap.BdryName,nb));
+        REQUIRE(na==nb);
+        for (int n=0;n<na;++n) {
+            CComplex ac1,as1,br1,bs1,bt1,bts1, ac2,as2,br2,bs2,bt2,bts2;
+            REQUIRE(persisted.getGapHarmonics(gap.BdryName,n,ac1,as1,br1,bs1,bt1,bts1)==
+                   memory.getGapHarmonics(gap.BdryName,n,ac2,as2,br2,bs2,bt2,bts2));
+            REQUIRE(close(ac1,ac2)&&close(as1,as2)&&close(br1,br2)&&close(bs1,bs2)&&close(bt1,bt2)&&close(bts1,bts2));
+        }
+        double tq1=0,tq2=0;
+        REQUIRE(persisted.gapDCTorqueIntegral(gap.BdryName,tq1)==memory.gapDCTorqueIntegral(gap.BdryName,tq2));
+        REQUIRE(std::abs(tq1-tq2)<=1e-11*(1+std::abs(tq1)));
+        CComplex fx1,fy1,fx2,fy2;
+        REQUIRE(persisted.gapDCForceIntegral(gap.BdryName,fx1,fy1)==memory.gapDCForceIntegral(gap.BdryName,fx2,fy2));
+        REQUIRE(close(fx1,fx2)&&close(fy1,fy2));
+    }
+
+    const std::string copy = std::string(argv[1])+".snapshot-copy";
+    const auto diskSnapshot = MagneticSolutionSnapshot::fromAnsFile(argv[1]);
+    REQUIRE(diskSnapshot.writeAnsFile(copy));
+    FPProc roundTrip(MagneticSolutionSnapshot::fromAnsFile(copy));
+    REQUIRE(roundTrip.numNodes()==persisted.numNodes());
+    std::remove(copy.c_str());
+}


### PR DESCRIPTION
### Motivation

- Provide an immutable, in-memory representation of a solved magnetic state so post-processing can operate on snapshots without coupling to mutable document state.

### Description

- Add `MagneticSolutionSnapshot` abstraction to hold an immutable solver/post-processor state and preserve the original `.ans` bytes for faithful round-trips via `fromAnsFile` and `writeAnsFile` (new files `MagneticSolutionSnapshot.h` / `MagneticSolutionSnapshot.cpp`).
- Extend `FPProc` with a constructor that accepts a `MagneticSolutionSnapshot` and a `solutionSnapshot()` method to freeze the currently loaded solution into a snapshot (API changes to `fpproc.h` and implementation in `fpproc.cpp`).
- Implement deep-copy semantics when constructing an `FPProc` from a snapshot, including mesh node/element lists, element adjacency (`NumList`/`ConList`), block/material/circuit lists, and thorough copying of AGE harmonic arrays so post-processing views are independent from the original reader state.
- Add a unit test `fpproc-snapshot-test` (`cfemm/fpproc/test/snapshot_parity_test.cpp`) that validates parity between on-disk `.ans`-loaded `FPProc` and an `FPProc` initialized from a snapshot for point values, block integrals, line integrals, circuit voltage/flux, AGE harmonics, force/torque, and `.ans` read/write round trips.
- Register snapshot parity tests in `cfemm/fpproc/CMakeLists.txt` and wire dependencies to pre-run solver/AGE fixtures for reliable test inputs.

### Testing

- Ran configuration and build: `cmake -S cfemm -B build -DCMAKE_BUILD_TYPE=Release` and `cmake --build build -j2` which succeeded.
- Ran full test suite: `ctest --test-dir build --output-on-failure` where all enabled tests passed (37 tests run) after adding the new parity tests; several repository comparison checks remain intentionally disabled by the existing test harness.
- Executed the new snapshot parity tests specifically (`fpproc_snapshot_parity` and `fpproc_snapshot_age_parity`) and verified they pass against the repository solver fixtures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b4a85e03c8326a4f7319e758d16b6)