### PR TITLE
Fix conjugate Hermitian sparse multiplication

### DIFF
--- a/cfemm/libfemm/CMakeLists.txt
+++ b/cfemm/libfemm/CMakeLists.txt
@@ -79,4 +79,6 @@ target_include_directories(femm
     $<INSTALL_INTERFACE:include>
     )
 target_link_libraries(femm PUBLIC luacomplex)
+
+add_subdirectory(test)
 # vi:expandtab:tabstop=4 shiftwidth=4:

--- a/cfemm/libfemm/cspars.cpp
+++ b/cfemm/libfemm/cspars.cpp
@@ -394,7 +394,7 @@ void CBigComplexLinProb::MultConjA(CComplex *X, CComplex *Y, int k)
             Y[i]+=(e->x.Conj()*X[e->c]);
             if (k==1)
                 Y[e->c]+=(e->x*X[i]);   // case in which the matrix is hermitian
-            if (k==3)
+            else if (k==3)
                 Y[e->c]+=(-e->x*X[i]);   // case in which the matrix is antihermitian
             else
                 Y[e->c]+=(e->x.Conj()*X[i]); // case in which the matrix is complex-symmetric

--- a/cfemm/libfemm/test/CMakeLists.txt
+++ b/cfemm/libfemm/test/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(cspars_multiply_test cspars_multiply_test.cpp)
+target_link_libraries(cspars_multiply_test PRIVATE femm)
+
+add_test(NAME cspars_multiply COMMAND cspars_multiply_test)
+set_tests_properties(cspars_multiply PROPERTIES LABELS "libfemm;unit")

--- a/cfemm/libfemm/test/cspars_multiply_test.cpp
+++ b/cfemm/libfemm/test/cspars_multiply_test.cpp
@@ -1,0 +1,142 @@
+#include "femmcomplex.h"
+#include "cspars.h"
+
+#include <array>
+#include <cmath>
+#include <complex>
+#include <iostream>
+#include <string>
+
+namespace {
+
+constexpr std::size_t Dimension = 3;
+using Complex = std::complex<double>;
+using Vector = std::array<Complex, Dimension>;
+using Matrix = std::array<std::array<Complex, Dimension>, Dimension>;
+
+Vector multiply(const Matrix &matrix, const Vector &vector)
+{
+    Vector result{};
+    for (std::size_t row = 0; row < Dimension; ++row)
+        for (std::size_t column = 0; column < Dimension; ++column)
+            result[row] += matrix[row][column] * vector[column];
+    return result;
+}
+
+Matrix conjugate(const Matrix &matrix)
+{
+    Matrix result{};
+    for (std::size_t row = 0; row < Dimension; ++row)
+        for (std::size_t column = 0; column < Dimension; ++column)
+            result[row][column] = std::conj(matrix[row][column]);
+    return result;
+}
+
+Vector conjugate(const Vector &vector)
+{
+    Vector result{};
+    for (std::size_t i = 0; i < Dimension; ++i) result[i] = std::conj(vector[i]);
+    return result;
+}
+
+Vector operator+(Vector left, const Vector &right)
+{
+    for (std::size_t i = 0; i < Dimension; ++i) left[i] += right[i];
+    return left;
+}
+
+Vector operator-(Vector left, const Vector &right)
+{
+    for (std::size_t i = 0; i < Dimension; ++i) left[i] -= right[i];
+    return left;
+}
+
+void storeUpperTriangle(CBigComplexLinProb &problem, const Matrix &matrix, int kind)
+{
+    for (std::size_t row = 0; row < Dimension; ++row)
+        for (std::size_t column = row; column < Dimension; ++column)
+            problem.Put(CComplex(matrix[row][column].real(), matrix[row][column].imag()),
+                    static_cast<int>(row), static_cast<int>(column), kind);
+}
+
+bool check(const std::string &name, const Vector &expected, const CComplex *actual)
+{
+    constexpr double tolerance = 1.e-12;
+    for (std::size_t i = 0; i < Dimension; ++i) {
+        const Complex value(actual[i].re, actual[i].im);
+        if (std::abs(value - expected[i]) > tolerance) {
+            std::cerr << name << '[' << i << "]: expected " << expected[i]
+                      << ", got " << value << '\n';
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+int main()
+{
+    const Matrix symmetric{{
+        {{{2., 1.}, {1., -2.}, {-3., .5}}},
+        {{{1., -2.}, {4., -1.}, {.25, 3.}}},
+        {{{-3., .5}, {.25, 3.}, {-2., 2.}}}
+    }};
+    const Matrix hermitian{{
+        {{{1.5, 0.}, {2., 3.}, {-1., .75}}},
+        {{{2., -3.}, {-2.5, 0.}, {4., -1.}}},
+        {{{-1., -.75}, {4., 1.}, {3.5, 0.}}}
+    }};
+    const Matrix antiHermitian{{
+        {{{0., 2.}, {1., -4.}, {2.5, .5}}},
+        {{{-1., -4.}, {0., -3.}, {-2., 1.5}}},
+        {{{-2.5, .5}, {2., 1.5}, {0., .25}}}
+    }};
+    const Matrix auxiliarySymmetric{{
+        {{{-.5, 1.}, {3., .25}, {1.25, -2.}}},
+        {{{3., .25}, {2., .5}, {-1., -1.5}}},
+        {{{1.25, -2.}, {-1., -1.5}, {4., -3.}}}
+    }};
+    const Vector input{{{1., -1.}, {-.5, 2.}, {3., .25}}};
+    std::array<CComplex, Dimension> x;
+    std::array<CComplex, Dimension> actual;
+    for (std::size_t i = 0; i < Dimension; ++i)
+        x[i] = CComplex(input[i].real(), input[i].imag());
+
+    CBigComplexLinProb problem;
+    problem.Create(static_cast<int>(Dimension), 0, static_cast<int>(Dimension));
+    storeUpperTriangle(problem, symmetric, 0);
+    storeUpperTriangle(problem, hermitian, 1);
+    storeUpperTriangle(problem, auxiliarySymmetric, 2);
+    storeUpperTriangle(problem, antiHermitian, 3);
+
+    bool ok = true;
+    const std::array<Matrix, 4> matrices{{symmetric, hermitian, auxiliarySymmetric,
+                                         antiHermitian}};
+    const std::array<std::string, 4> names{{"symmetric", "Hermitian",
+                                            "auxiliary symmetric", "anti-Hermitian"}};
+    for (int kind = 0; kind < 4; ++kind) {
+        problem.MultA(x.data(), actual.data(), kind);
+        ok &= check("MultA " + names[kind], multiply(matrices[kind], input), actual.data());
+        problem.MultConjA(x.data(), actual.data(), kind);
+        ok &= check("MultConjA " + names[kind],
+                multiply(conjugate(matrices[kind]), input), actual.data());
+    }
+
+    problem.MultA(x.data(), actual.data(), -1);
+    const Vector combinedMinusOne = multiply(symmetric, input)
+            + multiply(hermitian, input)
+            + conjugate(multiply(conjugate(auxiliarySymmetric), input))
+            + multiply(antiHermitian, input);
+    ok &= check("MultA k=-1", combinedMinusOne, actual.data());
+
+    problem.MultA(x.data(), actual.data(), -2);
+    const Vector auxiliaryProduct = multiply(auxiliarySymmetric, input);
+    const Vector combinedMinusTwo = multiply(symmetric, input)
+            + multiply(conjugate(hermitian), input)
+            + auxiliaryProduct + conjugate(auxiliaryProduct)
+            - multiply(conjugate(antiHermitian), input);
+    ok &= check("MultA k=-2", combinedMinusTwo, actual.data());
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
### Motivation

- Correct a logic bug in `CBigComplexLinProb::MultConjA` where the Hermitian off-diagonal case could also execute the generic complex-symmetric branch, producing incorrect contributions for certain matrix kinds.
- Add focused unit coverage to ensure `MultA` and `MultConjA` behave exactly like dense reference multiplications across ordinary complex-symmetric, Hermitian, anti-Hermitian, and Newton auxiliary matrices, and to validate the combined `k == -1` and `k == -2` Newton paths.
- Check whether the same defect exists in the original FEMM sources to inform compatibility and potential upstream fixes.

### Description

- Make the off-diagonal branch in `CBigComplexLinProb::MultConjA` mutually exclusive by changing the `k == 3` test to `else if (k == 3)` so `k == 1`, `k == 3`, and the generic case are exclusive (`cfemm/libfemm/cspars.cpp`).
- Add a new unit test `cfemm/libfemm/test/cspars_multiply_test.cpp` that constructs small dense reference matrices using `std::complex`, stores their upper triangles into the sparse structure, and compares every output component of `MultA` and `MultConjA` against independently computed dense products (including validation of `k == -1` and `k == -2` combined Newton behaviour).
- Register the focused test in `cfemm/libfemm/test/CMakeLists.txt` and enable it via `add_subdirectory(test)` in `cfemm/libfemm/CMakeLists.txt` so the test builds with the library.
- During investigation, located the same two-`if` pattern in the original FEMM magnetic Newton solver (`fkn/cspars.cpp` in the public mirror) where the Hermitian `if` was followed by a separate anti-Hermitian `if` and an `else` that could execute for the Hermitian case.

### Testing

- Configured and built the library and test with `cmake -S cfemm -B /tmp/xfemm-build -DTRIANGLE_PROVIDER=force-builtin` which completed successfully.
- Built the new test with `cmake --build /tmp/xfemm-build --target cspars_multiply_test -j2` which completed successfully.
- Executed the focused test with `ctest --test-dir /tmp/xfemm-build -R '^cspars_multiply$' --output-on-failure` and the `cspars_multiply` test passed (1/1 tests passed).
- Performed repository checks for introduced whitespace issues and the build/test run completed without failing checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fee03868c83268c729c4ca85b8e19)