### PR TITLE
Resolve merge conflicts and standardize mesher backend to `XFEMM_MESHER_BACKEND`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,7 @@ jobs:
         cd cfemm
         cmake -B ${{github.workspace}}/build \
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-          -DXFEMM_TEST_MESHER_BACKEND=${{matrix.mesher-backend}}
+          -DXFEMM_MESHER_BACKEND=${{matrix.mesher-backend}}
 
     - name: Build
       # Build your program with the given configuration

--- a/README.md
+++ b/README.md
@@ -51,17 +51,17 @@ this would be done as
 
 the binary files are found in the xfemm/cfemm/bin directory
 
-### Selecting a mesher for the standard tests
+### Selecting the default mesher backend
 
 The CMake test build uses Triangle by default. To run the complete standard test
 suite with the Tangle backend selected wherever xfemm constructs its default
 mesher, use a separate build directory:
 
-    cmake -S cfemm -B build-tangle -DXFEMM_TEST_MESHER_BACKEND=Tangle
+    cmake -S cfemm -B build-tangle -DXFEMM_MESHER_BACKEND=Tangle
     cmake --build build-tangle
     ctest --test-dir build-tangle --output-on-failure
 
-`XFEMM_TEST_MESHER_BACKEND` accepts only `Triangle` or `Tangle`. It controls the
+`XFEMM_MESHER_BACKEND` accepts only `Triangle` or `Tangle`. It controls the
 default used by the fmesher executable, femmcli meshing commands, and
 `AnalysisSession`, so the normal mesher/solver/post-processor tests exercise the
 selected path rather than a backend-specific subset. The fmesher command line can

--- a/cfemm/femmcli/test/CMakeLists.txt
+++ b/cfemm/femmcli/test/CMakeLists.txt
@@ -26,7 +26,7 @@ function(test_lua testname)
     endif()
     set_tests_properties(${testname}.lua PROPERTIES
         LABELS "lua;${test_lua_LABELS}"
-        ENVIRONMENT "XFEMM_TEST_MESHER_BACKEND=${XFEMM_TEST_MESHER_BACKEND}"
+        ENVIRONMENT "XFEMM_MESHER_BACKEND=${XFEMM_MESHER_BACKEND}"
         )
 endfunction()
 

--- a/cfemm/femmcli/test/femmcli_epproc.lua
+++ b/cfemm/femmcli/test/femmcli_epproc.lua
@@ -32,7 +32,7 @@ V,Dx,Dy,Ex,Ey,ex,ey,nrg  = eo_getpointvalues(0.250, 0)
 -- check result against FEMM42 output:
 -- FIXME: error margin needs sane values
 failed=0
-if getenv("XFEMM_TEST_MESHER_BACKEND") == "Tangle" then
+if getenv("XFEMM_MESHER_BACKEND") == "Tangle" then
 	V_ref = 48.90577131945231
 	Dx_ref = 8.387310310792659e-010
 	Dy_ref = 6.043844822898733e-011

--- a/cfemm/femmcli/test/femmcli_fpproc.lua
+++ b/cfemm/femmcli/test/femmcli_fpproc.lua
@@ -33,7 +33,7 @@ A,B1,B2,Sig,E,H1,H2,Je,Js,Mu1,Mu2,Pe,Ph = mo_getpointvalues(0.250, 0)
 -- check result against FEMM42 output:
 -- FIXME: error margin needs sane values
 failed=0
-if getenv("XFEMM_TEST_MESHER_BACKEND") == "Tangle" then
+if getenv("XFEMM_MESHER_BACKEND") == "Tangle" then
 	A_ref = 1.240205148710215e-014
 	B1_ref = -1.050120917482506e-013
 	B2_ref = 2.635532930443618e-014

--- a/cfemm/femmcli/test/femmcli_hpproc.lua
+++ b/cfemm/femmcli/test/femmcli_hpproc.lua
@@ -34,7 +34,7 @@ failed=0
 -- check result against FEMM42 output:
 -- FIXME: error margin needs sane values
 print("Checks against femm42 output:")
-if getenv("XFEMM_TEST_MESHER_BACKEND") == "Tangle" then
+if getenv("XFEMM_MESHER_BACKEND") == "Tangle" then
 	T_ref = 304.8996961164884
 	Fx_ref = 0.07573299004184463
 	Fy_ref = 0.07330545755661612

--- a/cfemm/fmesher/CMakeLists.txt
+++ b/cfemm/fmesher/CMakeLists.txt
@@ -17,13 +17,13 @@ set(TANGLE_SOURCE_DIR "" CACHE PATH
     "Path to a dcm3c/tangle source checkout (required by TANGLE_PROVIDER=local).")
 set(XFEMM_TANGLE_REVISION a808c624ec0584569e43593662f54890b602c6af CACHE STRING
     "Pinned dcm3c/tangle revision used by xfemm.")
-set(XFEMM_TEST_MESHER_BACKEND Triangle CACHE STRING
-    "Default mesher backend used by the standard test build (Triangle or Tangle).")
-set_property(CACHE XFEMM_TEST_MESHER_BACKEND PROPERTY STRINGS Triangle Tangle)
-string(TOLOWER "${XFEMM_TEST_MESHER_BACKEND}" _xfemm_test_mesher_backend)
-if(NOT _xfemm_test_mesher_backend MATCHES "^(triangle|tangle)$")
+set(XFEMM_MESHER_BACKEND Triangle CACHE STRING
+    "Default xfemm mesher backend (Triangle or Tangle).")
+set_property(CACHE XFEMM_MESHER_BACKEND PROPERTY STRINGS Triangle Tangle)
+string(TOLOWER "${XFEMM_MESHER_BACKEND}" _xfemm_mesher_backend)
+if(NOT _xfemm_mesher_backend MATCHES "^(triangle|tangle)$")
     message(FATAL_ERROR
-        "Invalid XFEMM_TEST_MESHER_BACKEND='${XFEMM_TEST_MESHER_BACKEND}'; expected Triangle or Tangle")
+        "Invalid XFEMM_MESHER_BACKEND='${XFEMM_MESHER_BACKEND}'; expected Triangle or Tangle")
 endif()
 
 if(NOT TANGLE_PROVIDER MATCHES "^(auto|local|fetch)$")
@@ -101,10 +101,10 @@ add_library(fmesher STATIC
     )
 target_link_libraries(fmesher PUBLIC femm PRIVATE Triangle::triangle-api Tangle::tangle)
 target_include_directories(fmesher PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
-if(_xfemm_test_mesher_backend STREQUAL "tangle")
-    target_compile_definitions(fmesher PUBLIC XFEMM_DEFAULT_MESHER_BACKEND_TANGLE)
+if(_xfemm_mesher_backend STREQUAL "tangle")
+    target_compile_definitions(fmesher PUBLIC XFEMM_MESHER_BACKEND_TANGLE)
 endif()
-message(STATUS "Standard tests use the ${XFEMM_TEST_MESHER_BACKEND} mesher backend")
+message(STATUS "Default xfemm mesher backend: ${XFEMM_MESHER_BACKEND}")
 
 add_executable(fmesher-bin
     main.cpp

--- a/cfemm/fmesher/fmesher.h
+++ b/cfemm/fmesher/fmesher.h
@@ -110,7 +110,7 @@ public:
     static femm::FileType GetFileType(std::string PathName);
     static constexpr Backend defaultBackend()
     {
-#ifdef XFEMM_DEFAULT_MESHER_BACKEND_TANGLE
+#ifdef XFEMM_MESHER_BACKEND_TANGLE
         return Backend::Tangle;
 #else
         return Backend::Triangle;

--- a/cfemm/fmesher/test/CMakeLists.txt
+++ b/cfemm/fmesher/test/CMakeLists.txt
@@ -17,8 +17,8 @@ test_fmesher(split_seg_err_test.fem)
 add_test(NAME fmesher_selected_backend
     COMMAND fmesher-bin --version)
 set_tests_properties(fmesher_selected_backend PROPERTIES
-    PASS_REGULAR_EXPRESSION "default mesher backend ${XFEMM_TEST_MESHER_BACKEND}"
-    LABELS "mesher;${XFEMM_TEST_MESHER_BACKEND}")
+    PASS_REGULAR_EXPRESSION "default mesher backend ${XFEMM_MESHER_BACKEND}"
+    LABELS "mesher;${XFEMM_MESHER_BACKEND}")
 # vi:expandtab:tabstop=4 shiftwidth=4:
 
 add_executable(fmesher_backend_test backend_test.cpp)

--- a/cfemm/fsolver/AnalysisSession.cpp
+++ b/cfemm/fsolver/AnalysisSession.cpp
@@ -19,7 +19,7 @@ std::atomic<std::uint64_t> nextSessionId{1};
 
 std::shared_ptr<fmesher::MesherBackend> makeDefaultMesher()
 {
-#ifdef XFEMM_DEFAULT_MESHER_BACKEND_TANGLE
+#ifdef XFEMM_MESHER_BACKEND_TANGLE
     return std::make_shared<fmesher::TangleMesherBackend>();
 #else
     return std::make_shared<fmesher::TriangleMesherBackend>();


### PR DESCRIPTION
### Motivation

- Finish merging the branch changes into the target branch and resolve content conflicts that arose in the femmcli tests and fmesher CMake files.  
- Standardize the mesher backend configuration name so the build, CI matrix and runtime tests use a single variable.  
- Ensure Lua-based test scripts and compile-time switches follow the renamed configuration so both Triangle and Tangle backends are exercised properly.

### Description

- Renamed the cache/config variable from `XFEMM_TEST_MESHER_BACKEND` to `XFEMM_MESHER_BACKEND` and updated all references in CMake, CI and documentation files.  
- Updated `cfemm/fmesher/CMakeLists.txt` to use `XFEMM_MESHER_BACKEND`, added `TangleMeshConverter.cpp` to the `fmesher` sources, and switched the compile-time macro to `XFEMM_MESHER_BACKEND_TANGLE`.  
- Forwarded the selected backend into the Lua test environment by setting `ENVIRONMENT "XFEMM_MESHER_BACKEND=${XFEMM_MESHER_BACKEND}"` in `cfemm/femmcli/test/CMakeLists.txt` and updated the Lua tests to check `getenv("XFEMM_MESHER_BACKEND")`.  
- Updated runtime/compile-time checks to use the new macro (`fmesher.h`, `fsolver/AnalysisSession.cpp`) and adjusted the femmcli test check logic to use `validate_solution.cmake` for `.ans` checks.

### Testing

- Configured the build with `cmake -S cfemm -B build -DCMAKE_BUILD_TYPE=Release -DTANGLE_PROVIDER=auto` and observed the default mesher backend message.  
- Built the project with `cmake --build build -j2` and then built `femmcli` with `cmake --build build -j2 --target femmcli-bin` with no compile errors.  
- Ran the full CTest suite with `ctest --test-dir build --output-on-failure` and observed that all enabled tests passed; specifically, all 46 enabled tests passed and 5 pre-existing, intentionally-disabled tests remained not run.  
- Verified there are no unresolved conflict markers and `git diff --check` returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a878b95f9648326972e0d92db6330de)