### PR TITLE
Add backend-neutral SolverMesh invariant validator

### DIFF
--- a/cfemm/fmesher/test/backend_test.cpp
+++ b/cfemm/fmesher/test/backend_test.cpp
@@ -3,9 +3,9 @@
 #include "TriangleMesherBackend.h"
 #include "fmesher.h"
 #include "FemmReader.h"
+#include "mesh/SolverMeshValidator.h"
 
 #include <chrono>
-#include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
@@ -19,47 +19,6 @@ bool parseProblem(const char *path, fmesher::FMesher &facade)
     facade.problem->filetype = femm::FileType::MagneticsFile;
     femm::MagneticsReader reader(facade.problem, std::cerr);
     return reader.parse(path) == femm::F_FILE_OK;
-}
-
-bool validNodeIndex(femm::mesh::MeshIndex index, const femm::mesh::SolverMesh &mesh)
-{
-    return index < mesh.nodes.size();
-}
-
-bool validGeometry(const femm::mesh::SolverMesh &mesh)
-{
-    if (mesh.nodes.empty() || mesh.elements.empty() || mesh.edges.empty()) return false;
-    for (const auto &node : mesh.nodes)
-        if (!std::isfinite(node.x) || !std::isfinite(node.y)) return false;
-    for (const auto &element : mesh.elements)
-        for (const auto node : element.nodes)
-            if (!validNodeIndex(node, mesh)) return false;
-    for (const auto &edge : mesh.edges)
-        if (!validNodeIndex(edge.first, mesh) || !validNodeIndex(edge.second, mesh)) return false;
-    return true;
-}
-
-bool validPeriodicTopology(const femm::mesh::SolverMesh &mesh)
-{
-    for (const auto &constraint : mesh.periodicConstraints)
-        if (!validNodeIndex(constraint.first, mesh) || !validNodeIndex(constraint.second, mesh))
-            return false;
-    for (const auto &airGap : mesh.airGaps) {
-        if (airGap.totalArcElements == 0 || airGap.quadraturePoints.empty()
-                || airGap.nodeIndices.empty() || airGap.innerRing.empty()
-                || airGap.outerRing.empty()
-                || airGap.innerRing.size() != airGap.outerRing.size()) return false;
-        for (const auto node : airGap.nodeIndices)
-            if (!validNodeIndex(node, mesh)) return false;
-        for (const auto &point : airGap.quadraturePoints)
-            for (const auto node : point.nodes)
-                if (!validNodeIndex(node, mesh)) return false;
-        for (const auto &point : airGap.innerRing)
-            if (!validNodeIndex(point.node, mesh)) return false;
-        for (const auto &point : airGap.outerRing)
-            if (!validNodeIndex(point.node, mesh)) return false;
-    }
-    return true;
 }
 
 int fail(const std::string &message)
@@ -105,18 +64,25 @@ int main(int argc, char **argv)
     std::filesystem::current_path(originalDirectory);
     std::filesystem::remove_all(scratchDirectory);
 
-    if (!result.succeeded() || !validGeometry(result.mesh))
+    if (!result.succeeded() || result.mesh.nodes.empty() || result.mesh.elements.empty()
+            || result.mesh.edges.empty() || !femm::mesh::validateSolverMesh(result.mesh).valid())
         return fail("Non-periodic backend result was incomplete");
     if (!result.mesh.periodicConstraints.empty() || !result.mesh.airGaps.empty())
         return fail("Non-periodic backend result contained periodic topology");
-    if (!periodicResult.succeeded() || !validGeometry(periodicResult.mesh)
+    if (!periodicResult.succeeded() || periodicResult.mesh.nodes.empty()
+            || periodicResult.mesh.elements.empty() || periodicResult.mesh.edges.empty()
             || periodicResult.mesh.periodicConstraints.empty()
             || !periodicResult.mesh.airGaps.empty()
-            || !validPeriodicTopology(periodicResult.mesh))
+            || !femm::mesh::validateSolverMesh(periodicResult.mesh).valid())
         return fail("Ordinary periodic backend result was incomplete");
-    if (!ageResult.succeeded() || !validGeometry(ageResult.mesh)
-            || ageResult.mesh.airGaps.empty() || !validPeriodicTopology(ageResult.mesh))
+    if (!ageResult.succeeded() || ageResult.mesh.nodes.empty()
+            || ageResult.mesh.elements.empty() || ageResult.mesh.edges.empty()
+            || ageResult.mesh.airGaps.empty()
+            || !femm::mesh::validateSolverMesh(ageResult.mesh).valid())
         return fail("AGE backend result was incomplete");
+    for (const auto &airGap : ageResult.mesh.airGaps)
+        if (airGap.nodeIndices.empty() || airGap.innerRing.empty() || airGap.outerRing.empty())
+            return fail("AGE backend result omitted expected reusable topology");
     if (createdFile) return fail(backendName + "MesherBackend created a file");
 
     femm::mesh::SolverMesh::Node markerProbe;

--- a/cfemm/libfemm/CMakeLists.txt
+++ b/cfemm/libfemm/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(femm
     spars.cpp
     stringTools.cpp
     linsolve/backend_factory.cpp
+    mesh/SolverMeshValidator.cpp
     )
 if(XFEMM_USE_PETSc)
     target_sources(femm PRIVATE linsolve/PetscLinearSystemBackend.cpp)

--- a/cfemm/libfemm/mesh/SolverMeshValidator.cpp
+++ b/cfemm/libfemm/mesh/SolverMeshValidator.cpp
@@ -1,0 +1,151 @@
+#include "SolverMeshValidator.h"
+
+#include <algorithm>
+#include <cmath>
+#include <set>
+
+namespace femm {
+namespace mesh {
+namespace {
+
+void add(SolverMeshValidationResult &result, SolverMeshValidationCategory category,
+         std::size_t objectIndex, std::size_t localIndex, const std::string &context)
+{
+    result.diagnostics.push_back({category, objectIndex, localIndex, context});
+}
+
+bool validNode(MeshIndex node, std::size_t count)
+{
+    return node < count;
+}
+
+bool validPeriodicity(SolverMesh::Periodicity value)
+{
+    return value == SolverMesh::Periodicity::Periodic ||
+           value == SolverMesh::Periodicity::Antiperiodic;
+}
+
+} // namespace
+
+SolverMeshValidationResult validateSolverMesh(const SolverMesh &mesh)
+{
+    SolverMeshValidationResult result;
+    std::set<std::pair<MeshIndex, MeshIndex>> elementEdges;
+    for (std::size_t i = 0; i < mesh.nodes.size(); ++i) {
+        if (!std::isfinite(mesh.nodes[i].x))
+            add(result, SolverMeshValidationCategory::NonFiniteNodeCoordinate, i, 0, "x");
+        if (!std::isfinite(mesh.nodes[i].y))
+            add(result, SolverMeshValidationCategory::NonFiniteNodeCoordinate, i, 1, "y");
+    }
+
+    for (std::size_t i = 0; i < mesh.elements.size(); ++i) {
+        const auto &element = mesh.elements[i];
+        bool connectivityValid = true;
+        for (std::size_t j = 0; j < element.nodes.size(); ++j) {
+            if (!validNode(element.nodes[j], mesh.nodes.size())) {
+                add(result, SolverMeshValidationCategory::InvalidElementNode, i, j, "element node");
+                connectivityValid = false;
+            }
+        }
+        if (!connectivityValid)
+            continue;
+        if (element.nodes[0] == element.nodes[1] || element.nodes[1] == element.nodes[2] ||
+            element.nodes[2] == element.nodes[0]) {
+            add(result, SolverMeshValidationCategory::RepeatedElementNode, i, 0, "element");
+            continue;
+        }
+        const auto &a = mesh.nodes[element.nodes[0]];
+        const auto &b = mesh.nodes[element.nodes[1]];
+        const auto &c = mesh.nodes[element.nodes[2]];
+        const double twiceArea = (b.x - a.x) * (c.y - a.y) -
+                                 (b.y - a.y) * (c.x - a.x);
+        if (!std::isfinite(twiceArea))
+            add(result, SolverMeshValidationCategory::NonFiniteElementArea, i, 0, "signed area");
+        else if (twiceArea <= 0.0)
+            add(result, SolverMeshValidationCategory::NonPositiveElementArea, i, 0, "signed area");
+        for (std::size_t j = 0; j < 3; ++j) {
+            const MeshIndex first = element.nodes[j];
+            const MeshIndex second = element.nodes[(j + 1) % 3];
+            elementEdges.insert(std::minmax(first, second));
+        }
+    }
+
+    for (std::size_t i = 0; i < mesh.edges.size(); ++i) {
+        const auto &edge = mesh.edges[i];
+        bool connectivityValid = true;
+        if (!validNode(edge.first, mesh.nodes.size())) {
+            add(result, SolverMeshValidationCategory::InvalidEdgeNode, i, 0, "first");
+            connectivityValid = false;
+        }
+        if (!validNode(edge.second, mesh.nodes.size())) {
+            add(result, SolverMeshValidationCategory::InvalidEdgeNode, i, 1, "second");
+            connectivityValid = false;
+        }
+        if (!connectivityValid)
+            continue;
+        if (edge.first == edge.second) {
+            add(result, SolverMeshValidationCategory::SelfEdge, i, 0, "edge");
+            continue;
+        }
+        if (elementEdges.count(std::minmax(edge.first, edge.second)) == 0)
+            add(result, SolverMeshValidationCategory::EdgeNotOwnedByElement, i, 0, "edge");
+    }
+
+    for (std::size_t i = 0; i < mesh.periodicConstraints.size(); ++i) {
+        const auto &constraint = mesh.periodicConstraints[i];
+        if (!validNode(constraint.first, mesh.nodes.size()))
+            add(result, SolverMeshValidationCategory::InvalidPeriodicNode, i, 0, "first");
+        if (!validNode(constraint.second, mesh.nodes.size()))
+            add(result, SolverMeshValidationCategory::InvalidPeriodicNode, i, 1, "second");
+        if (validNode(constraint.first, mesh.nodes.size()) && constraint.first == constraint.second)
+            add(result, SolverMeshValidationCategory::SelfPeriodicConstraint, i, 0, "constraint");
+        if (!validPeriodicity(constraint.periodicity))
+            add(result, SolverMeshValidationCategory::InvalidPeriodicity, i, 0, "constraint");
+    }
+
+    for (std::size_t i = 0; i < mesh.airGaps.size(); ++i) {
+        const auto &gap = mesh.airGaps[i];
+        const std::string context = gap.boundaryName.empty() ? "<unnamed>" : gap.boundaryName;
+        const double scalars[] = {gap.totalArcLengthDegrees, gap.innerRadius, gap.outerRadius,
+                                  gap.innerAngleDegrees, gap.outerAngleDegrees, gap.innerShift,
+                                  gap.outerShift, gap.centerX, gap.centerY};
+        for (std::size_t j = 0; j < sizeof(scalars) / sizeof(scalars[0]); ++j)
+            if (!std::isfinite(scalars[j]))
+                add(result, SolverMeshValidationCategory::NonFiniteAirGapValue, i, j, context);
+        if (!validPeriodicity(gap.periodicity))
+            add(result, SolverMeshValidationCategory::InvalidPeriodicity, i, 0, context);
+        if (gap.totalArcElements == 0 || gap.totalArcLengthDegrees <= 0.0 ||
+            gap.innerRadius <= 0.0 || gap.outerRadius <= gap.innerRadius)
+            add(result, SolverMeshValidationCategory::InvalidAirGapGeometry, i, 0, context);
+        if (gap.innerRing.empty() != gap.outerRing.empty() ||
+            (!gap.innerRing.empty() && gap.innerRing.size() != gap.outerRing.size()))
+            add(result, SolverMeshValidationCategory::InvalidAirGapStructure, i, 0, context);
+
+        for (std::size_t q = 0; q < gap.quadraturePoints.size(); ++q) {
+            for (std::size_t j = 0; j < 4; ++j) {
+                if (!validNode(gap.quadraturePoints[q].nodes[j], mesh.nodes.size()))
+                    add(result, SolverMeshValidationCategory::InvalidAirGapQuadratureNode, i, q * 4 + j, context);
+                if (!std::isfinite(gap.quadraturePoints[q].weights[j]))
+                    add(result, SolverMeshValidationCategory::NonFiniteAirGapQuadratureWeight, i, q * 4 + j, context);
+            }
+        }
+        const std::vector<SolverMesh::AirGapRingPoint> *rings[] = {&gap.innerRing, &gap.outerRing};
+        for (std::size_t r = 0; r < 2; ++r) {
+            const std::string ringContext = context + (r == 0 ? "/innerRing" : "/outerRing");
+            for (std::size_t j = 0; j < rings[r]->size(); ++j) {
+                const auto &point = (*rings[r])[j];
+                if (!validNode(point.node, mesh.nodes.size()))
+                    add(result, SolverMeshValidationCategory::InvalidAirGapRingNode, i, j, ringContext);
+                if (!std::isfinite(point.elementPosition) || !std::isfinite(point.weight))
+                    add(result, SolverMeshValidationCategory::NonFiniteAirGapRingValue, i, j, ringContext);
+            }
+        }
+        for (std::size_t j = 0; j < gap.nodeIndices.size(); ++j)
+            if (!validNode(gap.nodeIndices[j], mesh.nodes.size()))
+                add(result, SolverMeshValidationCategory::InvalidAirGapNodeIndex, i, j, context);
+    }
+    return result;
+}
+
+} // namespace mesh
+} // namespace femm

--- a/cfemm/libfemm/mesh/SolverMeshValidator.cpp
+++ b/cfemm/libfemm/mesh/SolverMeshValidator.cpp
@@ -97,8 +97,6 @@ SolverMeshValidationResult validateSolverMesh(const SolverMesh &mesh)
             add(result, SolverMeshValidationCategory::InvalidPeriodicNode, i, 0, "first");
         if (!validNode(constraint.second, mesh.nodes.size()))
             add(result, SolverMeshValidationCategory::InvalidPeriodicNode, i, 1, "second");
-        if (validNode(constraint.first, mesh.nodes.size()) && constraint.first == constraint.second)
-            add(result, SolverMeshValidationCategory::SelfPeriodicConstraint, i, 0, "constraint");
         if (!validPeriodicity(constraint.periodicity))
             add(result, SolverMeshValidationCategory::InvalidPeriodicity, i, 0, "constraint");
     }
@@ -117,8 +115,12 @@ SolverMeshValidationResult validateSolverMesh(const SolverMesh &mesh)
         if (gap.totalArcElements == 0 || gap.totalArcLengthDegrees <= 0.0 ||
             gap.innerRadius <= 0.0 || gap.outerRadius <= gap.innerRadius)
             add(result, SolverMeshValidationCategory::InvalidAirGapGeometry, i, 0, context);
-        if (gap.innerRing.empty() != gap.outerRing.empty() ||
-            (!gap.innerRing.empty() && gap.innerRing.size() != gap.outerRing.size()))
+        const bool ringsPresent = !gap.innerRing.empty() && !gap.outerRing.empty();
+        if (gap.quadraturePoints.empty() ||
+            gap.quadraturePoints.size() - 1 != gap.totalArcElements ||
+            gap.innerRing.empty() != gap.outerRing.empty() ||
+            (ringsPresent && (gap.innerRing.size() != gap.outerRing.size() ||
+                              gap.innerRing.size() < gap.totalArcElements)))
             add(result, SolverMeshValidationCategory::InvalidAirGapStructure, i, 0, context);
 
         for (std::size_t q = 0; q < gap.quadraturePoints.size(); ++q) {

--- a/cfemm/libfemm/mesh/SolverMeshValidator.h
+++ b/cfemm/libfemm/mesh/SolverMeshValidator.h
@@ -20,7 +20,6 @@ enum class SolverMeshValidationCategory {
     SelfEdge,
     EdgeNotOwnedByElement,
     InvalidPeriodicNode,
-    SelfPeriodicConstraint,
     InvalidPeriodicity,
     NonFiniteAirGapValue,
     InvalidAirGapGeometry,

--- a/cfemm/libfemm/mesh/SolverMeshValidator.h
+++ b/cfemm/libfemm/mesh/SolverMeshValidator.h
@@ -1,0 +1,54 @@
+#ifndef FEMM_MESH_SOLVERMESHVALIDATOR_H
+#define FEMM_MESH_SOLVERMESHVALIDATOR_H
+
+#include "SolverMesh.h"
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace femm {
+namespace mesh {
+
+enum class SolverMeshValidationCategory {
+    NonFiniteNodeCoordinate,
+    InvalidElementNode,
+    RepeatedElementNode,
+    NonFiniteElementArea,
+    NonPositiveElementArea,
+    InvalidEdgeNode,
+    SelfEdge,
+    EdgeNotOwnedByElement,
+    InvalidPeriodicNode,
+    SelfPeriodicConstraint,
+    InvalidPeriodicity,
+    NonFiniteAirGapValue,
+    InvalidAirGapGeometry,
+    InvalidAirGapStructure,
+    InvalidAirGapQuadratureNode,
+    NonFiniteAirGapQuadratureWeight,
+    InvalidAirGapRingNode,
+    NonFiniteAirGapRingValue,
+    InvalidAirGapNodeIndex
+};
+
+/** One deterministic, machine-readable failure found in a SolverMesh. */
+struct SolverMeshValidationDiagnostic {
+    SolverMeshValidationCategory category;
+    std::size_t objectIndex = 0;
+    std::size_t localIndex = 0;
+    std::string context;
+};
+
+struct SolverMeshValidationResult {
+    std::vector<SolverMeshValidationDiagnostic> diagnostics;
+    bool valid() const { return diagnostics.empty(); }
+};
+
+/** Validate a completed SolverMesh without making assumptions about its backend. */
+SolverMeshValidationResult validateSolverMesh(const SolverMesh &mesh);
+
+} // namespace mesh
+} // namespace femm
+
+#endif

--- a/cfemm/libfemm/test/CMakeLists.txt
+++ b/cfemm/libfemm/test/CMakeLists.txt
@@ -9,3 +9,9 @@ target_link_libraries(material_curve_test PRIVATE femm)
 
 add_test(NAME material_curve COMMAND material_curve_test)
 set_tests_properties(material_curve PROPERTIES LABELS "libfemm;unit")
+
+add_executable(solver_mesh_validator_test solver_mesh_validator_test.cpp)
+target_link_libraries(solver_mesh_validator_test PRIVATE femm)
+
+add_test(NAME solver_mesh_validator COMMAND solver_mesh_validator_test)
+set_tests_properties(solver_mesh_validator PROPERTIES LABELS "libfemm;mesh;unit")

--- a/cfemm/libfemm/test/solver_mesh_validator_test.cpp
+++ b/cfemm/libfemm/test/solver_mesh_validator_test.cpp
@@ -28,6 +28,7 @@ SolverMesh ageMesh()
     gap.innerRadius = 0.5;
     gap.outerRadius = 1.0;
     gap.quadraturePoints.push_back({{{0, 1, 1, 2}}, {{0.5, 0.5, 0.5, 0.5}}});
+    gap.quadraturePoints.push_back({{{1, 2, 2, 0}}, {{0.5, 0.5, 0.5, 0.5}}});
     gap.innerRing = {{0, 0.0, 1.0}, {1, 1.0, 1.0}};
     gap.outerRing = {{1, 0.0, 1.0}, {2, 1.0, 1.0}};
     gap.nodeIndices = {0, 1, 1, 2};
@@ -40,6 +41,17 @@ bool has(const SolverMesh &mesh, SolverMeshValidationCategory category)
     const auto result = femm::mesh::validateSolverMesh(mesh);
     for (const auto &diagnostic : result.diagnostics)
         if (diagnostic.category == category)
+            return true;
+    return false;
+}
+
+bool hasDiagnostic(const SolverMesh &mesh, SolverMeshValidationCategory category,
+                   std::size_t objectIndex, std::size_t localIndex, const std::string &context)
+{
+    const auto result = femm::mesh::validateSolverMesh(mesh);
+    for (const auto &diagnostic : result.diagnostics)
+        if (diagnostic.category == category && diagnostic.objectIndex == objectIndex &&
+            diagnostic.localIndex == localIndex && diagnostic.context == context)
             return true;
     return false;
 }
@@ -64,15 +76,30 @@ int main()
     mesh.periodicConstraints.push_back({0, 1, SolverMesh::Periodicity::Antiperiodic});
     if (!femm::mesh::validateSolverMesh(mesh).valid() || !mesh.airGaps.empty())
         return fail("ordinary periodic mesh without AGE was rejected");
+    mesh.periodicConstraints = {
+        {0, 0, SolverMesh::Periodicity::Periodic},
+        {1, 1, SolverMesh::Periodicity::Antiperiodic}
+    };
+    if (!femm::mesh::validateSolverMesh(mesh).valid())
+        return fail("valid periodic and antiperiodic self-pairs were rejected");
     if (!femm::mesh::validateSolverMesh(ageMesh()).valid())
         return fail("synthetic AGE mesh was rejected");
+    mesh = ageMesh();
+    mesh.airGaps[0].innerRing.clear();
+    mesh.airGaps[0].outerRing.clear();
+    if (!femm::mesh::validateSolverMesh(mesh).valid())
+        return fail("valid legacy-compatible AGE without reusable rings was rejected");
 
     mesh = ordinaryMesh(); mesh.nodes[0].x = std::numeric_limits<double>::quiet_NaN();
     EXPECT_CATEGORY(mesh, NonFiniteNodeCoordinate);
+    if (!hasDiagnostic(mesh, SolverMeshValidationCategory::NonFiniteNodeCoordinate, 0, 0, "x"))
+        return fail("node diagnostic did not identify its coordinate");
     mesh = ordinaryMesh(); mesh.nodes[0].y = std::numeric_limits<double>::infinity();
     EXPECT_CATEGORY(mesh, NonFiniteNodeCoordinate);
     mesh = ordinaryMesh(); mesh.elements[0].nodes[2] = 99;
     EXPECT_CATEGORY(mesh, InvalidElementNode);
+    if (!hasDiagnostic(mesh, SolverMeshValidationCategory::InvalidElementNode, 0, 2, "element node"))
+        return fail("element diagnostic did not identify its local node");
     mesh = ordinaryMesh(); mesh.elements[0].nodes[2] = 1;
     EXPECT_CATEGORY(mesh, RepeatedElementNode);
     mesh = ordinaryMesh(); mesh.nodes[2] = {2.0, 0.0, 0};
@@ -91,8 +118,6 @@ int main()
     EXPECT_CATEGORY(mesh, EdgeNotOwnedByElement);
     mesh = ordinaryMesh(); mesh.periodicConstraints.push_back({0, 99, SolverMesh::Periodicity::Periodic});
     EXPECT_CATEGORY(mesh, InvalidPeriodicNode);
-    mesh = ordinaryMesh(); mesh.periodicConstraints.push_back({0, 0, SolverMesh::Periodicity::Periodic});
-    EXPECT_CATEGORY(mesh, SelfPeriodicConstraint);
     mesh = ordinaryMesh(); mesh.periodicConstraints.push_back({0, 1, static_cast<SolverMesh::Periodicity>(99)});
     EXPECT_CATEGORY(mesh, InvalidPeriodicity);
 
@@ -102,12 +127,25 @@ int main()
     EXPECT_CATEGORY(mesh, InvalidAirGapGeometry);
     mesh = ageMesh(); mesh.airGaps[0].outerRing.pop_back();
     EXPECT_CATEGORY(mesh, InvalidAirGapStructure);
+    mesh = ageMesh(); mesh.airGaps[0].quadraturePoints.pop_back();
+    EXPECT_CATEGORY(mesh, InvalidAirGapStructure);
+    mesh = ageMesh(); mesh.airGaps[0].quadraturePoints.push_back(mesh.airGaps[0].quadraturePoints.back());
+    EXPECT_CATEGORY(mesh, InvalidAirGapStructure);
+    mesh = ageMesh(); mesh.airGaps[0].totalArcElements = 3;
+    mesh.airGaps[0].quadraturePoints.resize(4, mesh.airGaps[0].quadraturePoints.back());
+    EXPECT_CATEGORY(mesh, InvalidAirGapStructure);
     mesh = ageMesh(); mesh.airGaps[0].quadraturePoints[0].nodes[2] = 99;
     EXPECT_CATEGORY(mesh, InvalidAirGapQuadratureNode);
+    if (!hasDiagnostic(mesh, SolverMeshValidationCategory::InvalidAirGapQuadratureNode,
+                       0, 2, "synthetic gap"))
+        return fail("AGE diagnostic did not identify its gap and quadrature node");
     mesh = ageMesh(); mesh.airGaps[0].quadraturePoints[0].weights[1] = std::numeric_limits<double>::infinity();
     EXPECT_CATEGORY(mesh, NonFiniteAirGapQuadratureWeight);
     mesh = ageMesh(); mesh.airGaps[0].innerRing[0].node = 99;
     EXPECT_CATEGORY(mesh, InvalidAirGapRingNode);
+    if (!hasDiagnostic(mesh, SolverMeshValidationCategory::InvalidAirGapRingNode,
+                       0, 0, "synthetic gap/innerRing"))
+        return fail("AGE ring diagnostic did not identify its ring");
     mesh = ageMesh(); mesh.airGaps[0].outerRing[0].elementPosition = std::numeric_limits<double>::quiet_NaN();
     EXPECT_CATEGORY(mesh, NonFiniteAirGapRingValue);
     mesh = ageMesh(); mesh.airGaps[0].innerRing[0].weight = std::numeric_limits<double>::infinity();

--- a/cfemm/libfemm/test/solver_mesh_validator_test.cpp
+++ b/cfemm/libfemm/test/solver_mesh_validator_test.cpp
@@ -1,0 +1,119 @@
+#include "mesh/SolverMeshValidator.h"
+
+#include <cmath>
+#include <iostream>
+#include <limits>
+
+using femm::mesh::SolverMesh;
+using femm::mesh::SolverMeshValidationCategory;
+
+namespace {
+
+SolverMesh ordinaryMesh()
+{
+    SolverMesh mesh;
+    mesh.nodes = {{0.0, 0.0, 0}, {1.0, 0.0, 0}, {0.0, 1.0, 0}};
+    mesh.elements.push_back({{{0, 1, 2}}, 1});
+    mesh.edges = {{0, 1, 0}, {1, 2, 0}, {2, 0, 0}};
+    return mesh;
+}
+
+SolverMesh ageMesh()
+{
+    SolverMesh mesh = ordinaryMesh();
+    SolverMesh::AirGap gap;
+    gap.boundaryName = "synthetic gap";
+    gap.totalArcElements = 1;
+    gap.totalArcLengthDegrees = 90.0;
+    gap.innerRadius = 0.5;
+    gap.outerRadius = 1.0;
+    gap.quadraturePoints.push_back({{{0, 1, 1, 2}}, {{0.5, 0.5, 0.5, 0.5}}});
+    gap.innerRing = {{0, 0.0, 1.0}, {1, 1.0, 1.0}};
+    gap.outerRing = {{1, 0.0, 1.0}, {2, 1.0, 1.0}};
+    gap.nodeIndices = {0, 1, 1, 2};
+    mesh.airGaps.push_back(gap);
+    return mesh;
+}
+
+bool has(const SolverMesh &mesh, SolverMeshValidationCategory category)
+{
+    const auto result = femm::mesh::validateSolverMesh(mesh);
+    for (const auto &diagnostic : result.diagnostics)
+        if (diagnostic.category == category)
+            return true;
+    return false;
+}
+
+int fail(const char *message)
+{
+    std::cerr << message << '\n';
+    return 1;
+}
+
+#define EXPECT_CATEGORY(mesh, category) \
+    if (!has((mesh), SolverMeshValidationCategory::category)) return fail("missing " #category)
+
+} // namespace
+
+int main()
+{
+    if (!femm::mesh::validateSolverMesh(ordinaryMesh()).valid())
+        return fail("ordinary mesh was rejected");
+
+    auto mesh = ordinaryMesh();
+    mesh.periodicConstraints.push_back({0, 1, SolverMesh::Periodicity::Antiperiodic});
+    if (!femm::mesh::validateSolverMesh(mesh).valid() || !mesh.airGaps.empty())
+        return fail("ordinary periodic mesh without AGE was rejected");
+    if (!femm::mesh::validateSolverMesh(ageMesh()).valid())
+        return fail("synthetic AGE mesh was rejected");
+
+    mesh = ordinaryMesh(); mesh.nodes[0].x = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_CATEGORY(mesh, NonFiniteNodeCoordinate);
+    mesh = ordinaryMesh(); mesh.nodes[0].y = std::numeric_limits<double>::infinity();
+    EXPECT_CATEGORY(mesh, NonFiniteNodeCoordinate);
+    mesh = ordinaryMesh(); mesh.elements[0].nodes[2] = 99;
+    EXPECT_CATEGORY(mesh, InvalidElementNode);
+    mesh = ordinaryMesh(); mesh.elements[0].nodes[2] = 1;
+    EXPECT_CATEGORY(mesh, RepeatedElementNode);
+    mesh = ordinaryMesh(); mesh.nodes[2] = {2.0, 0.0, 0};
+    EXPECT_CATEGORY(mesh, NonPositiveElementArea);
+    mesh = ordinaryMesh(); std::swap(mesh.elements[0].nodes[1], mesh.elements[0].nodes[2]);
+    EXPECT_CATEGORY(mesh, NonPositiveElementArea);
+    mesh = ordinaryMesh(); mesh.nodes[1].x = std::numeric_limits<double>::max();
+    mesh.nodes[2].y = std::numeric_limits<double>::max();
+    EXPECT_CATEGORY(mesh, NonFiniteElementArea);
+
+    mesh = ordinaryMesh(); mesh.edges[0].first = 99;
+    EXPECT_CATEGORY(mesh, InvalidEdgeNode);
+    mesh = ordinaryMesh(); mesh.edges[0].second = mesh.edges[0].first;
+    EXPECT_CATEGORY(mesh, SelfEdge);
+    mesh = ordinaryMesh(); mesh.nodes.push_back({2.0, 2.0, 0}); mesh.edges[0] = {0, 3, 0};
+    EXPECT_CATEGORY(mesh, EdgeNotOwnedByElement);
+    mesh = ordinaryMesh(); mesh.periodicConstraints.push_back({0, 99, SolverMesh::Periodicity::Periodic});
+    EXPECT_CATEGORY(mesh, InvalidPeriodicNode);
+    mesh = ordinaryMesh(); mesh.periodicConstraints.push_back({0, 0, SolverMesh::Periodicity::Periodic});
+    EXPECT_CATEGORY(mesh, SelfPeriodicConstraint);
+    mesh = ordinaryMesh(); mesh.periodicConstraints.push_back({0, 1, static_cast<SolverMesh::Periodicity>(99)});
+    EXPECT_CATEGORY(mesh, InvalidPeriodicity);
+
+    mesh = ageMesh(); mesh.airGaps[0].centerX = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_CATEGORY(mesh, NonFiniteAirGapValue);
+    mesh = ageMesh(); mesh.airGaps[0].outerRadius = mesh.airGaps[0].innerRadius;
+    EXPECT_CATEGORY(mesh, InvalidAirGapGeometry);
+    mesh = ageMesh(); mesh.airGaps[0].outerRing.pop_back();
+    EXPECT_CATEGORY(mesh, InvalidAirGapStructure);
+    mesh = ageMesh(); mesh.airGaps[0].quadraturePoints[0].nodes[2] = 99;
+    EXPECT_CATEGORY(mesh, InvalidAirGapQuadratureNode);
+    mesh = ageMesh(); mesh.airGaps[0].quadraturePoints[0].weights[1] = std::numeric_limits<double>::infinity();
+    EXPECT_CATEGORY(mesh, NonFiniteAirGapQuadratureWeight);
+    mesh = ageMesh(); mesh.airGaps[0].innerRing[0].node = 99;
+    EXPECT_CATEGORY(mesh, InvalidAirGapRingNode);
+    mesh = ageMesh(); mesh.airGaps[0].outerRing[0].elementPosition = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_CATEGORY(mesh, NonFiniteAirGapRingValue);
+    mesh = ageMesh(); mesh.airGaps[0].innerRing[0].weight = std::numeric_limits<double>::infinity();
+    EXPECT_CATEGORY(mesh, NonFiniteAirGapRingValue);
+    mesh = ageMesh(); mesh.airGaps[0].nodeIndices[2] = 99;
+    EXPECT_CATEGORY(mesh, InvalidAirGapNodeIndex);
+
+    return 0;
+}

--- a/docs/instanced-mesh-task-breakdown.md
+++ b/docs/instanced-mesh-task-breakdown.md
@@ -71,7 +71,7 @@ returns a validated `SolverMesh`, and is trustworthy enough to become the defaul
 
 ### A3 — Establish differential confidence
 
-- [ ] **A3.1: Build a backend-neutral mesh invariant checker.**
+- [x] **A3.1: Build a backend-neutral mesh invariant checker.**
   - Depends on: A2.1.
   - Check finite coordinates, valid connectivity, positive element area,
     boundary-edge ownership, PBC indices/types, and every AGE node reference.


### PR DESCRIPTION
### Motivation

- Provide a small, backend-neutral validation gate for completed `SolverMesh` values so mesher backends and later instancing code can reliably detect malformed meshes before the solver consumes them.
- Satisfy A3.1 of the instanced-mesh plan by centralizing structural checks that are independent of Triangle/Tangle ordering or other backend-specific details.

### Description

- Added a value-oriented validation API `validateSolverMesh(const SolverMesh&)` that returns a `SolverMeshValidationResult` containing deterministic `SolverMeshValidationDiagnostic` entries with a category, owning object index, local index, and short `context` string; declarations live in `cfemm/libfemm/mesh/SolverMeshValidator.h` and implementation in `cfemm/libfemm/mesh/SolverMeshValidator.cpp`.
- Implemented invariants covering: finite node coordinates; valid element node indices; three distinct nodes per triangle; finite, strictly positive signed triangle area (orientation); valid edge indices, non-self edges, and edge ownership by at least one element; valid ordinary periodic constraints and recognised periodicity values; and comprehensive AGE checks including finite scalar geometry, sensible radii/arc parameters, inner/outer ring structural compatibility, valid `AirGapQuadraturePoint` node references and finite weights, valid `AirGapRingPoint::node` references and finite elementPosition/weight, and `AirGap::nodeIndices` validity.
- Diagnostics are produced without assertions or unchecked indexing (no UB or crashes) and are machine-friendly for unit testing via stable enum categories and compact contextual text.
- Hooked the implementation and a focused unit test into CMake (`cfemm/libfemm/CMakeLists.txt` and `cfemm/libfemm/test/CMakeLists.txt`) and updated `docs/instanced-mesh-task-breakdown.md` to mark A3.1 complete.

### Testing

- Built the project: `cmake -S cfemm -B build -DCMAKE_BUILD_TYPE=Release` and `cmake --build build` (configuration and build succeeded; unrelated pre-existing compiler warnings remain).
- Ran focused tests: `solver_mesh_validator` unit test passed and exercises valid ordinary, PBC-only (no AGE), and synthetic AGE meshes plus one failing case per implemented diagnostic category.
- Ran mesher and integration tests used by the plan: `fmesher_tangle_mesh_converter`, `fmesher_tangle_backend_execution`, and the Triangle/Tangle solver-mesh backend tests — all relevant tests passed.
- Ran full configured CTest suite in this build; all enabled tests passed (47/47 enabled tests passed; several pre-existing tests remained disabled by upstream config) and `git diff --check` produced no issues.

If any additional diagnostics, categories, or context formatting are desired for downstream differential tests or for richer failure reporting, the API returns a compact vector of diagnostics suitable for reuse by backends and `InstancedMesh::materialize()` without changing the validator internals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a982d7c56148326894a883ed8e39f4a)