### PR TITLE
A3.2: Add ordinary / periodic / antiperiodic mesher differential fixtures and test

### DIFF
--- a/cfemm/fpproc/CMakeLists.txt
+++ b/cfemm/fpproc/CMakeLists.txt
@@ -34,3 +34,14 @@ install(
     COMPONENT "cli (debug)"
     CONFIGURATIONS "Debug")
 # vi:expandtab:tabstop=4 shiftwidth=4:
+
+add_executable(a3_2_mesher_differential_test
+    test/a3_2_mesher_differential_test.cpp)
+target_link_libraries(a3_2_mesher_differential_test PRIVATE fpproc)
+add_test(NAME a3_2_mesher_differential
+    COMMAND a3_2_mesher_differential_test
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/fixtures/a3_2_nonperiodic.fem
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/fixtures/a3_2_periodic.fem
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/fixtures/a3_2_antiperiodic.fem)
+set_tests_properties(a3_2_mesher_differential PROPERTIES
+    LABELS "magnetics;mesher;solver;postprocessor;Triangle;Tangle;differential")

--- a/cfemm/fpproc/InMemorySolution.cpp
+++ b/cfemm/fpproc/InMemorySolution.cpp
@@ -34,6 +34,9 @@ bool FPProc::OpenDocument(const femm::FemmProblem &problem, const FSolver &solve
     nodeproplist = solver.nodeproplist;
     lineproplist = solver.lineproplist;
     blockproplist.clear();
+    // CMMaterialProp's legacy copy constructor does not preserve the transient
+    // MuMax flag. Avoid vector-growth copies after each explicitly prepared item.
+    blockproplist.reserve(solver.blockproplist.size());
     for (const auto &source : solver.blockproplist) {
         blockproplist.push_back(static_cast<const femm::CMMaterialProp &>(source));
         auto &item = blockproplist.back();

--- a/cfemm/fpproc/test/a3_2_mesher_differential_test.cpp
+++ b/cfemm/fpproc/test/a3_2_mesher_differential_test.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -26,6 +27,7 @@ struct Fixture {
     std::vector<Point> samples;
     Periodicity periodicity;
     bool hasPeriodicConstraints;
+    Tolerance potentialTolerance;
     Tolerance fieldTolerance;
     Tolerance integralTolerance;
 };
@@ -65,9 +67,38 @@ Run run(const Fixture &fixture, const std::string &backendName)
         throw std::runtime_error(fixture.name + "/" + backendName + " unexpectedly produced AGE topology");
     if (mesh->periodicConstraints.empty() != !fixture.hasPeriodicConstraints)
         throw std::runtime_error(fixture.name + "/" + backendName + " has wrong PBC presence");
-    for (const auto &constraint : mesh->periodicConstraints)
+    std::vector<unsigned> pairedNodeUses(mesh->nodes.size(), 0);
+    constexpr double boundaryTolerance = 1e-11;
+    for (const auto &constraint : mesh->periodicConstraints) {
         if (constraint.periodicity != fixture.periodicity)
             throw std::runtime_error(fixture.name + "/" + backendName + " has wrong PBC type");
+        const auto &first = mesh->nodes[constraint.first];
+        const auto &second = mesh->nodes[constraint.second];
+        const bool firstLowerSecondUpper =
+            std::abs(first.y + 1.0) <= boundaryTolerance &&
+            std::abs(second.y - 1.0) <= boundaryTolerance;
+        const bool firstUpperSecondLower =
+            std::abs(first.y - 1.0) <= boundaryTolerance &&
+            std::abs(second.y + 1.0) <= boundaryTolerance;
+        if ((!firstLowerSecondUpper && !firstUpperSecondLower) ||
+            std::abs(first.x - second.x) > boundaryTolerance)
+            throw std::runtime_error(fixture.name + "/" + backendName +
+                                     " has incorrect paired-boundary correspondence");
+        ++pairedNodeUses[constraint.first];
+        ++pairedNodeUses[constraint.second];
+    }
+    if (fixture.hasPeriodicConstraints) {
+        for (std::size_t i = 0; i < mesh->nodes.size(); ++i) {
+            const auto &node = mesh->nodes[i];
+            const bool onPairedBoundary =
+                (std::abs(node.y + 1.0) <= boundaryTolerance ||
+                 std::abs(node.y - 1.0) <= boundaryTolerance) &&
+                std::abs(node.x) < 1.0 - boundaryTolerance;
+            if (onPairedBoundary && pairedNodeUses[i] != 1)
+                throw std::runtime_error(fixture.name + "/" + backendName +
+                                         " does not pair every non-corner seam node exactly once");
+        }
+    }
 
     session->solve();
     auto postprocessor = std::make_unique<FPProc>();
@@ -79,12 +110,28 @@ Run run(const Fixture &fixture, const std::string &backendName)
     return {std::move(session), std::move(solver), std::move(postprocessor)};
 }
 
+bool finiteComparison(double triangle, double tangle, Tolerance tolerance,
+                      double &difference, double &permitted)
+{
+    if (!std::isfinite(triangle) || !std::isfinite(tangle))
+        return false;
+    difference = std::abs(triangle - tangle);
+    permitted = tolerance.absolute + tolerance.relative *
+        std::max(std::abs(triangle), std::abs(tangle));
+    return std::isfinite(difference) && std::isfinite(permitted);
+}
+
 void compare(const Fixture &fixture, const Point &point, const char *quantity,
              double triangle, double tangle, Tolerance tolerance)
 {
-    const double difference = std::abs(triangle - tangle);
-    const double permitted = tolerance.absolute + tolerance.relative *
-        std::max(std::abs(triangle), std::abs(tangle));
+    double difference = 0.0;
+    double permitted = 0.0;
+    if (!finiteComparison(triangle, tangle, tolerance, difference, permitted)) {
+        std::cerr << fixture.name << " (" << point.x << ", " << point.y << ") "
+                  << quantity << ": non-finite comparison: Triangle=" << triangle
+                  << " Tangle=" << tangle << '\n';
+        throw std::runtime_error(fixture.name + " " + quantity + " is non-finite");
+    }
     std::cout << fixture.name << " (" << point.x << ", " << point.y << ") "
               << quantity << ": Triangle=" << triangle << " Tangle=" << tangle
               << " abs-difference=" << difference << " tolerance=" << permitted << '\n';
@@ -96,17 +143,29 @@ void compareFixture(const Fixture &fixture)
 {
     auto triangle = run(fixture, "Triangle");
     auto tangle = run(fixture, "Tangle");
+    double triangleMaxB = 0.0;
+    double tangleMaxB = 0.0;
     for (const auto &point : fixture.samples) {
         CMPointVals tv, gv;
         if (!triangle.postprocessor->GetPointValues(point.x, point.y, tv) ||
             !tangle.postprocessor->GetPointValues(point.x, point.y, gv))
             throw std::runtime_error(fixture.name + " sample is outside a generated mesh");
+        compare(fixture, point, "A", tv.A.re, gv.A.re, fixture.potentialTolerance);
         compare(fixture, point, "B1", tv.B1.re, gv.B1.re, fixture.fieldTolerance);
         compare(fixture, point, "B2", tv.B2.re, gv.B2.re, fixture.fieldTolerance);
+        triangleMaxB = std::max(triangleMaxB, std::hypot(tv.B1.re, tv.B2.re));
+        tangleMaxB = std::max(tangleMaxB, std::hypot(gv.B1.re, gv.B2.re));
     }
     const Point global{0, 0};
-    compare(fixture, global, "energy", triangle.postprocessor->BlockIntegral(2).re,
-            tangle.postprocessor->BlockIntegral(2).re, fixture.integralTolerance);
+    const double triangleEnergy = triangle.postprocessor->BlockIntegral(2).re;
+    const double tangleEnergy = tangle.postprocessor->BlockIntegral(2).re;
+    if (!std::isfinite(triangleEnergy) || !std::isfinite(tangleEnergy) ||
+        triangleEnergy <= 1e-12 || tangleEnergy <= 1e-12 ||
+        !std::isfinite(triangleMaxB) || !std::isfinite(tangleMaxB) ||
+        triangleMaxB <= 1e-9 || tangleMaxB <= 1e-9)
+        throw std::runtime_error(fixture.name + " produced a non-finite or trivial solution");
+    compare(fixture, global, "energy", triangleEnergy, tangleEnergy,
+            fixture.integralTolerance);
     compare(fixture, global, "coenergy", triangle.postprocessor->BlockIntegral(17).re,
             tangle.postprocessor->BlockIntegral(17).re, fixture.integralTolerance);
 }
@@ -120,18 +179,34 @@ int main(int argc, char **argv)
         return 2;
     }
     try {
-        // The 0.08 m target element size gives several hundred linear elements.
-        // Point fields tolerate local element-gradient differences; domain integrals
-        // are appreciably less mesh-sensitive and therefore use tighter limits.
-        const std::vector<Point> samples{{-0.55, -0.35}, {-0.25, 0.30},
-                                         {0.20, -0.20}, {0.55, 0.40}};
+        double difference = 0.0;
+        double permitted = 0.0;
+        const Tolerance finiteProbe{1.0, 1.0};
+        if (finiteComparison(std::numeric_limits<double>::quiet_NaN(), 0.0,
+                             finiteProbe, difference, permitted) ||
+            finiteComparison(std::numeric_limits<double>::infinity(), 0.0,
+                             finiteProbe, difference, permitted) ||
+            finiteComparison(std::numeric_limits<double>::max(),
+                             -std::numeric_limits<double>::max(), finiteProbe,
+                             difference, permitted) ||
+            finiteComparison(1.0, 1.0,
+                             {std::numeric_limits<double>::max(),
+                              std::numeric_limits<double>::max()},
+                             difference, permitted))
+            throw std::runtime_error("finite comparison guard accepted a non-finite case");
+
+        // The off-centre current rectangle breaks both x and y symmetry. Samples
+        // stay at least 0.15 m from its interface and 0.25 m from the outer seams.
+        const std::vector<Point> samples{{-0.60, -0.55}, {-0.55, 0.40},
+                                         {-0.20, 0.20}, {0.70, 0.45},
+                                         {0.275, -0.25}};
         const std::vector<Fixture> fixtures{
             {"non-periodic", argv[1], samples, Periodicity::Periodic, false,
-             {1e-3, 0.03}, {1.0, 0.002}},
+             {5e-5, 0.002}, {1.5e-3, 0.02}, {0.1, 0.0025}},
             {"periodic", argv[2], samples, Periodicity::Periodic, true,
-             {2e-3, 0.02}, {1.0, 0.003}},
+             {5e-5, 0.0035}, {1.3e-3, 0.015}, {0.1, 0.0055}},
             {"antiperiodic", argv[3], samples, Periodicity::Antiperiodic, true,
-             {2e-3, 0.025}, {1.0, 0.005}}
+             {5e-5, 0.004}, {1.3e-3, 0.02}, {0.1, 0.0065}}
         };
         for (const auto &fixture : fixtures)
             compareFixture(fixture);

--- a/cfemm/fpproc/test/a3_2_mesher_differential_test.cpp
+++ b/cfemm/fpproc/test/a3_2_mesher_differential_test.cpp
@@ -1,0 +1,143 @@
+#include "AnalysisSession.h"
+#include "FSolverAnalysisBackend.h"
+#include "FemmReader.h"
+#include "TangleMesherBackend.h"
+#include "TriangleMesherBackend.h"
+#include "fpproc.h"
+#include "mesh/SolverMeshValidator.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Periodicity = femm::mesh::SolverMesh::Periodicity;
+
+struct Point { double x; double y; };
+struct Tolerance { double absolute; double relative; };
+struct Fixture {
+    std::string name;
+    std::string path;
+    std::vector<Point> samples;
+    Periodicity periodicity;
+    bool hasPeriodicConstraints;
+    Tolerance fieldTolerance;
+    Tolerance integralTolerance;
+};
+struct Run {
+    std::unique_ptr<femm::AnalysisSession> session;
+    std::shared_ptr<femm::FSolverAnalysisBackend> solver;
+    std::unique_ptr<FPProc> postprocessor;
+};
+
+std::unique_ptr<femm::FemmProblem> readProblem(const std::string &path)
+{
+    auto problem = std::make_unique<femm::FemmProblem>(femm::FileType::MagneticsFile);
+    auto parserView = std::shared_ptr<femm::FemmProblem>(problem.get(), [](femm::FemmProblem *) {});
+    femm::MagneticsReader reader(parserView, std::cerr);
+    if (reader.parse(path) != femm::F_FILE_OK)
+        throw std::runtime_error("could not parse " + path);
+    return problem;
+}
+
+Run run(const Fixture &fixture, const std::string &backendName)
+{
+    std::shared_ptr<fmesher::MesherBackend> mesher;
+    if (backendName == "Triangle")
+        mesher = std::make_shared<fmesher::TriangleMesherBackend>();
+    else
+        mesher = std::make_shared<fmesher::TangleMesherBackend>();
+    auto solver = std::make_shared<femm::FSolverAnalysisBackend>();
+    auto session = std::make_unique<femm::AnalysisSession>(
+        femm::ModelDefinition(readProblem(fixture.path)), mesher, solver);
+    const auto mesh = session->ensureMesh();
+    const auto validation = femm::mesh::validateSolverMesh(*mesh);
+    if (!validation.valid())
+        throw std::runtime_error(fixture.name + "/" + backendName + " produced invalid mesh");
+    if (mesh->nodes.empty() || mesh->elements.empty() || mesh->edges.empty())
+        throw std::runtime_error(fixture.name + "/" + backendName + " produced empty topology");
+    if (!mesh->airGaps.empty())
+        throw std::runtime_error(fixture.name + "/" + backendName + " unexpectedly produced AGE topology");
+    if (mesh->periodicConstraints.empty() != !fixture.hasPeriodicConstraints)
+        throw std::runtime_error(fixture.name + "/" + backendName + " has wrong PBC presence");
+    for (const auto &constraint : mesh->periodicConstraints)
+        if (constraint.periodicity != fixture.periodicity)
+            throw std::runtime_error(fixture.name + "/" + backendName + " has wrong PBC type");
+
+    session->solve();
+    auto postprocessor = std::make_unique<FPProc>();
+    if (!postprocessor->OpenDocument(session->model().problem(), solver->solvedSolver(),
+                                     solver->solvedSystem()))
+        throw std::runtime_error(fixture.name + "/" + backendName + " post-processing failed");
+    for (auto &label : postprocessor->blocklist)
+        label.IsSelected = true;
+    return {std::move(session), std::move(solver), std::move(postprocessor)};
+}
+
+void compare(const Fixture &fixture, const Point &point, const char *quantity,
+             double triangle, double tangle, Tolerance tolerance)
+{
+    const double difference = std::abs(triangle - tangle);
+    const double permitted = tolerance.absolute + tolerance.relative *
+        std::max(std::abs(triangle), std::abs(tangle));
+    std::cout << fixture.name << " (" << point.x << ", " << point.y << ") "
+              << quantity << ": Triangle=" << triangle << " Tangle=" << tangle
+              << " abs-difference=" << difference << " tolerance=" << permitted << '\n';
+    if (difference > permitted)
+        throw std::runtime_error(fixture.name + " " + quantity + " differential exceeded tolerance");
+}
+
+void compareFixture(const Fixture &fixture)
+{
+    auto triangle = run(fixture, "Triangle");
+    auto tangle = run(fixture, "Tangle");
+    for (const auto &point : fixture.samples) {
+        CMPointVals tv, gv;
+        if (!triangle.postprocessor->GetPointValues(point.x, point.y, tv) ||
+            !tangle.postprocessor->GetPointValues(point.x, point.y, gv))
+            throw std::runtime_error(fixture.name + " sample is outside a generated mesh");
+        compare(fixture, point, "B1", tv.B1.re, gv.B1.re, fixture.fieldTolerance);
+        compare(fixture, point, "B2", tv.B2.re, gv.B2.re, fixture.fieldTolerance);
+    }
+    const Point global{0, 0};
+    compare(fixture, global, "energy", triangle.postprocessor->BlockIntegral(2).re,
+            tangle.postprocessor->BlockIntegral(2).re, fixture.integralTolerance);
+    compare(fixture, global, "coenergy", triangle.postprocessor->BlockIntegral(17).re,
+            tangle.postprocessor->BlockIntegral(17).re, fixture.integralTolerance);
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    if (argc != 4) {
+        std::cerr << "expected non-periodic, periodic, and antiperiodic fixture paths\n";
+        return 2;
+    }
+    try {
+        // The 0.08 m target element size gives several hundred linear elements.
+        // Point fields tolerate local element-gradient differences; domain integrals
+        // are appreciably less mesh-sensitive and therefore use tighter limits.
+        const std::vector<Point> samples{{-0.55, -0.35}, {-0.25, 0.30},
+                                         {0.20, -0.20}, {0.55, 0.40}};
+        const std::vector<Fixture> fixtures{
+            {"non-periodic", argv[1], samples, Periodicity::Periodic, false,
+             {1e-3, 0.03}, {1.0, 0.002}},
+            {"periodic", argv[2], samples, Periodicity::Periodic, true,
+             {2e-3, 0.02}, {1.0, 0.003}},
+            {"antiperiodic", argv[3], samples, Periodicity::Antiperiodic, true,
+             {2e-3, 0.025}, {1.0, 0.005}}
+        };
+        for (const auto &fixture : fixtures)
+            compareFixture(fixture);
+    } catch (const std::exception &error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/cfemm/fpproc/test/fixtures/a3_2_antiperiodic.fem
+++ b/cfemm/fpproc/test/fixtures/a3_2_antiperiodic.fem
@@ -1,0 +1,81 @@
+[Format]      =  4.0
+[Frequency]   =  0
+[Precision]   =  1e-8
+[MinAngle]    =  30
+[Depth]       =  1
+[LengthUnits] =  meters
+[ProblemType] =  planar
+[Coordinates] =  cartesian
+[ACSolver]    =  0
+[PrevSoln]    = ""
+[PrevType]    =  0
+[Comment]     =  "A3.2 synthetic linear magnetostatic differential fixture"
+[PointProps]  =  0
+[BdryProps]   = 2
+  <BeginBdry>
+    <BdryName> = "Fixed A"
+    <BdryType> = 0
+    <A_0> = 0
+    <A_1> = 0
+    <A_2> = 0
+    <Phi> = 0
+    <c0> = 0
+    <c0i> = 0
+    <c1> = 0
+    <c1i> = 0
+    <Mu_ssd> = 0
+    <Sigma_ssd> = 0
+    <innerangle> = 0
+    <outerangle> = 0
+  <EndBdry>
+  <BeginBdry>
+    <BdryName> = "Antiperiodic pair"
+    <BdryType> = 5
+    <A_0> = 0
+    <A_1> = 0
+    <A_2> = 0
+    <Phi> = 0
+    <c0> = 0
+    <c0i> = 0
+    <c1> = 0
+    <c1i> = 0
+    <Mu_ssd> = 0
+    <Sigma_ssd> = 0
+    <innerangle> = 0
+    <outerangle> = 0
+  <EndBdry>
+[BlockProps]  = 1
+  <BeginBlock>
+    <BlockName> = "Current region"
+    <Mu_x> = 1
+    <Mu_y> = 1
+    <H_c> = 0
+    <H_cAngle> = 0
+    <J_re> = 1
+    <J_im> = 0
+    <Sigma> = 0
+    <d_lam> = 0
+    <Phi_h> = 0
+    <Phi_hx> = 0
+    <Phi_hy> = 0
+    <LamType> = 0
+    <LamFill> = 1
+    <NStrands> = 0
+    <WireD> = 0
+    <BHPoints> = 0
+  <EndBlock>
+[CircuitProps]  = 0
+[NumPoints] = 4
+-1 -1 0 0
+1 -1 0 0
+1 1 0 0
+-1 1 0 0
+[NumSegments] = 4
+0 1 -1 2 0 0
+1 2 -1 1 0 0
+2 3 -1 2 0 0
+3 0 -1 1 0 0
+[NumArcSegments] = 0
+[NumHoles] = 0
+[NumBlockLabels] = 1
+0 0 1 0.08 0 0 0 1 0

--- a/cfemm/fpproc/test/fixtures/a3_2_antiperiodic.fem
+++ b/cfemm/fpproc/test/fixtures/a3_2_antiperiodic.fem
@@ -9,7 +9,7 @@
 [ACSolver]    =  0
 [PrevSoln]    = ""
 [PrevType]    =  0
-[Comment]     =  "A3.2 synthetic linear magnetostatic differential fixture"
+[Comment]     =  "A3.2 asymmetric off-centre current-region differential fixture"
 [PointProps]  =  0
 [BdryProps]   = 2
   <BeginBdry>
@@ -44,9 +44,28 @@
     <innerangle> = 0
     <outerangle> = 0
   <EndBdry>
-[BlockProps]  = 1
+[BlockProps]  = 2
   <BeginBlock>
-    <BlockName> = "Current region"
+    <BlockName> = "Air"
+    <Mu_x> = 1
+    <Mu_y> = 1
+    <H_c> = 0
+    <H_cAngle> = 0
+    <J_re> = 0
+    <J_im> = 0
+    <Sigma> = 0
+    <d_lam> = 0
+    <Phi_h> = 0
+    <Phi_hx> = 0
+    <Phi_hy> = 0
+    <LamType> = 0
+    <LamFill> = 1
+    <NStrands> = 0
+    <WireD> = 0
+    <BHPoints> = 0
+  <EndBlock>
+  <BeginBlock>
+    <BlockName> = "Off-centre current region"
     <Mu_x> = 1
     <Mu_y> = 1
     <H_c> = 0
@@ -65,17 +84,26 @@
     <BHPoints> = 0
   <EndBlock>
 [CircuitProps]  = 0
-[NumPoints] = 4
+[NumPoints] = 8
 -1 -1 0 0
 1 -1 0 0
 1 1 0 0
 -1 1 0 0
-[NumSegments] = 4
+0.05 -0.45 0 0
+0.50 -0.45 0 0
+0.50 -0.05 0 0
+0.05 -0.05 0 0
+[NumSegments] = 8
 0 1 -1 2 0 0
 1 2 -1 1 0 0
 2 3 -1 2 0 0
 3 0 -1 1 0 0
+4 5 -1 0 0 0
+5 6 -1 0 0 0
+6 7 -1 0 0 0
+7 4 -1 0 0 0
 [NumArcSegments] = 0
 [NumHoles] = 0
-[NumBlockLabels] = 1
-0 0 1 0.08 0 0 0 1 0
+[NumBlockLabels] = 2
+-0.55 0.35 1 0.07 0 0 0 1 0
+0.275 -0.25 2 0.045 0 0 0 1 0

--- a/cfemm/fpproc/test/fixtures/a3_2_nonperiodic.fem
+++ b/cfemm/fpproc/test/fixtures/a3_2_nonperiodic.fem
@@ -1,0 +1,65 @@
+[Format]      =  4.0
+[Frequency]   =  0
+[Precision]   =  1e-8
+[MinAngle]    =  30
+[Depth]       =  1
+[LengthUnits] =  meters
+[ProblemType] =  planar
+[Coordinates] =  cartesian
+[ACSolver]    =  0
+[PrevSoln]    = ""
+[PrevType]    =  0
+[Comment]     =  "A3.2 synthetic linear magnetostatic differential fixture"
+[PointProps]  =  0
+[BdryProps]   = 1
+  <BeginBdry>
+    <BdryName> = "Fixed A"
+    <BdryType> = 0
+    <A_0> = 0
+    <A_1> = 0
+    <A_2> = 0
+    <Phi> = 0
+    <c0> = 0
+    <c0i> = 0
+    <c1> = 0
+    <c1i> = 0
+    <Mu_ssd> = 0
+    <Sigma_ssd> = 0
+    <innerangle> = 0
+    <outerangle> = 0
+  <EndBdry>
+[BlockProps]  = 1
+  <BeginBlock>
+    <BlockName> = "Current region"
+    <Mu_x> = 1
+    <Mu_y> = 1
+    <H_c> = 0
+    <H_cAngle> = 0
+    <J_re> = 1
+    <J_im> = 0
+    <Sigma> = 0
+    <d_lam> = 0
+    <Phi_h> = 0
+    <Phi_hx> = 0
+    <Phi_hy> = 0
+    <LamType> = 0
+    <LamFill> = 1
+    <NStrands> = 0
+    <WireD> = 0
+    <BHPoints> = 0
+  <EndBlock>
+[CircuitProps]  = 0
+[NumPoints] = 4
+-1 -1 0 0
+1 -1 0 0
+1 1 0 0
+-1 1 0 0
+[NumSegments] = 4
+0 1 -1 1 0 0
+1 2 -1 1 0 0
+2 3 -1 1 0 0
+3 0 -1 1 0 0
+[NumArcSegments] = 0
+[NumHoles] = 0
+[NumBlockLabels] = 1
+0 0 1 0.08 0 0 0 1 0

--- a/cfemm/fpproc/test/fixtures/a3_2_nonperiodic.fem
+++ b/cfemm/fpproc/test/fixtures/a3_2_nonperiodic.fem
@@ -9,7 +9,7 @@
 [ACSolver]    =  0
 [PrevSoln]    = ""
 [PrevType]    =  0
-[Comment]     =  "A3.2 synthetic linear magnetostatic differential fixture"
+[Comment]     =  "A3.2 asymmetric off-centre current-region differential fixture"
 [PointProps]  =  0
 [BdryProps]   = 1
   <BeginBdry>
@@ -28,9 +28,28 @@
     <innerangle> = 0
     <outerangle> = 0
   <EndBdry>
-[BlockProps]  = 1
+[BlockProps]  = 2
   <BeginBlock>
-    <BlockName> = "Current region"
+    <BlockName> = "Air"
+    <Mu_x> = 1
+    <Mu_y> = 1
+    <H_c> = 0
+    <H_cAngle> = 0
+    <J_re> = 0
+    <J_im> = 0
+    <Sigma> = 0
+    <d_lam> = 0
+    <Phi_h> = 0
+    <Phi_hx> = 0
+    <Phi_hy> = 0
+    <LamType> = 0
+    <LamFill> = 1
+    <NStrands> = 0
+    <WireD> = 0
+    <BHPoints> = 0
+  <EndBlock>
+  <BeginBlock>
+    <BlockName> = "Off-centre current region"
     <Mu_x> = 1
     <Mu_y> = 1
     <H_c> = 0
@@ -49,17 +68,26 @@
     <BHPoints> = 0
   <EndBlock>
 [CircuitProps]  = 0
-[NumPoints] = 4
+[NumPoints] = 8
 -1 -1 0 0
 1 -1 0 0
 1 1 0 0
 -1 1 0 0
-[NumSegments] = 4
+0.05 -0.45 0 0
+0.50 -0.45 0 0
+0.50 -0.05 0 0
+0.05 -0.05 0 0
+[NumSegments] = 8
 0 1 -1 1 0 0
 1 2 -1 1 0 0
 2 3 -1 1 0 0
 3 0 -1 1 0 0
+4 5 -1 0 0 0
+5 6 -1 0 0 0
+6 7 -1 0 0 0
+7 4 -1 0 0 0
 [NumArcSegments] = 0
 [NumHoles] = 0
-[NumBlockLabels] = 1
-0 0 1 0.08 0 0 0 1 0
+[NumBlockLabels] = 2
+-0.55 0.35 1 0.07 0 0 0 1 0
+0.275 -0.25 2 0.045 0 0 0 1 0

--- a/cfemm/fpproc/test/fixtures/a3_2_periodic.fem
+++ b/cfemm/fpproc/test/fixtures/a3_2_periodic.fem
@@ -1,0 +1,81 @@
+[Format]      =  4.0
+[Frequency]   =  0
+[Precision]   =  1e-8
+[MinAngle]    =  30
+[Depth]       =  1
+[LengthUnits] =  meters
+[ProblemType] =  planar
+[Coordinates] =  cartesian
+[ACSolver]    =  0
+[PrevSoln]    = ""
+[PrevType]    =  0
+[Comment]     =  "A3.2 synthetic linear magnetostatic differential fixture"
+[PointProps]  =  0
+[BdryProps]   = 2
+  <BeginBdry>
+    <BdryName> = "Fixed A"
+    <BdryType> = 0
+    <A_0> = 0
+    <A_1> = 0
+    <A_2> = 0
+    <Phi> = 0
+    <c0> = 0
+    <c0i> = 0
+    <c1> = 0
+    <c1i> = 0
+    <Mu_ssd> = 0
+    <Sigma_ssd> = 0
+    <innerangle> = 0
+    <outerangle> = 0
+  <EndBdry>
+  <BeginBdry>
+    <BdryName> = "Periodic pair"
+    <BdryType> = 4
+    <A_0> = 0
+    <A_1> = 0
+    <A_2> = 0
+    <Phi> = 0
+    <c0> = 0
+    <c0i> = 0
+    <c1> = 0
+    <c1i> = 0
+    <Mu_ssd> = 0
+    <Sigma_ssd> = 0
+    <innerangle> = 0
+    <outerangle> = 0
+  <EndBdry>
+[BlockProps]  = 1
+  <BeginBlock>
+    <BlockName> = "Current region"
+    <Mu_x> = 1
+    <Mu_y> = 1
+    <H_c> = 0
+    <H_cAngle> = 0
+    <J_re> = 1
+    <J_im> = 0
+    <Sigma> = 0
+    <d_lam> = 0
+    <Phi_h> = 0
+    <Phi_hx> = 0
+    <Phi_hy> = 0
+    <LamType> = 0
+    <LamFill> = 1
+    <NStrands> = 0
+    <WireD> = 0
+    <BHPoints> = 0
+  <EndBlock>
+[CircuitProps]  = 0
+[NumPoints] = 4
+-1 -1 0 0
+1 -1 0 0
+1 1 0 0
+-1 1 0 0
+[NumSegments] = 4
+0 1 -1 2 0 0
+1 2 -1 1 0 0
+2 3 -1 2 0 0
+3 0 -1 1 0 0
+[NumArcSegments] = 0
+[NumHoles] = 0
+[NumBlockLabels] = 1
+0 0 1 0.08 0 0 0 1 0

--- a/cfemm/fpproc/test/fixtures/a3_2_periodic.fem
+++ b/cfemm/fpproc/test/fixtures/a3_2_periodic.fem
@@ -9,7 +9,7 @@
 [ACSolver]    =  0
 [PrevSoln]    = ""
 [PrevType]    =  0
-[Comment]     =  "A3.2 synthetic linear magnetostatic differential fixture"
+[Comment]     =  "A3.2 asymmetric off-centre current-region differential fixture"
 [PointProps]  =  0
 [BdryProps]   = 2
   <BeginBdry>
@@ -44,9 +44,28 @@
     <innerangle> = 0
     <outerangle> = 0
   <EndBdry>
-[BlockProps]  = 1
+[BlockProps]  = 2
   <BeginBlock>
-    <BlockName> = "Current region"
+    <BlockName> = "Air"
+    <Mu_x> = 1
+    <Mu_y> = 1
+    <H_c> = 0
+    <H_cAngle> = 0
+    <J_re> = 0
+    <J_im> = 0
+    <Sigma> = 0
+    <d_lam> = 0
+    <Phi_h> = 0
+    <Phi_hx> = 0
+    <Phi_hy> = 0
+    <LamType> = 0
+    <LamFill> = 1
+    <NStrands> = 0
+    <WireD> = 0
+    <BHPoints> = 0
+  <EndBlock>
+  <BeginBlock>
+    <BlockName> = "Off-centre current region"
     <Mu_x> = 1
     <Mu_y> = 1
     <H_c> = 0
@@ -65,17 +84,26 @@
     <BHPoints> = 0
   <EndBlock>
 [CircuitProps]  = 0
-[NumPoints] = 4
+[NumPoints] = 8
 -1 -1 0 0
 1 -1 0 0
 1 1 0 0
 -1 1 0 0
-[NumSegments] = 4
+0.05 -0.45 0 0
+0.50 -0.45 0 0
+0.50 -0.05 0 0
+0.05 -0.05 0 0
+[NumSegments] = 8
 0 1 -1 2 0 0
 1 2 -1 1 0 0
 2 3 -1 2 0 0
 3 0 -1 1 0 0
+4 5 -1 0 0 0
+5 6 -1 0 0 0
+6 7 -1 0 0 0
+7 4 -1 0 0 0
 [NumArcSegments] = 0
 [NumHoles] = 0
-[NumBlockLabels] = 1
-0 0 1 0.08 0 0 0 1 0
+[NumBlockLabels] = 2
+-0.55 0.35 1 0.07 0 0 0 1 0
+0.275 -0.25 2 0.045 0 0 0 1 0

--- a/docs/instanced-mesh-task-breakdown.md
+++ b/docs/instanced-mesh-task-breakdown.md
@@ -76,7 +76,7 @@ returns a validated `SolverMesh`, and is trustworthy enough to become the defaul
   - Check finite coordinates, valid connectivity, positive element area,
     boundary-edge ownership, PBC indices/types, and every AGE node reference.
   - Reuse it for both Tangle and Triangle tests.
-- [ ] **A3.2: Add ordinary and periodic differential fixtures.**
+- [x] **A3.2: Add ordinary and periodic differential fixtures.**
   - Depends on: A2.2 and A3.1.
   - Run both engines on checked-in non-periodic, periodic, and antiperiodic FEMM
     problems. Do not require identical node/element ordering or triangulation.


### PR DESCRIPTION
### Motivation

- Establish A3.2 differential confidence that `Triangle` and `Tangle` produce physically equivalent magnetostatic solutions while allowing different triangulations.
- Cover the required non-periodic, periodic, and antiperiodic cases without introducing Air Gap Elements (AGE), which remain deferred to A3.3.
- Exercise the full production path for both meshers: `MesherBackend` -> `SolverMesh` -> `AnalysisSession` -> `FSolverAnalysisBackend` -> in-memory `FPProc`.
- Make the periodic fixtures sensitive not only to the PBC type, but also to incorrect or reversed boundary-node correspondence.

### Description

This PR adds three compact deterministic linear magnetostatic fixtures:

- `cfemm/fpproc/test/fixtures/a3_2_nonperiodic.fem`
- `cfemm/fpproc/test/fixtures/a3_2_periodic.fem`
- `cfemm/fpproc/test/fixtures/a3_2_antiperiodic.fem`

All three use the same deliberately asymmetric geometry: a square `[-1,1] x [-1,1]` air domain containing an off-centre current-carrying rectangular region (`x = 0.05..0.50`, `y = -0.45..-0.05`). This breaks both x- and y-symmetry so that reversed, missing, or otherwise incorrect periodic-boundary correspondence materially changes the solved field instead of being hidden by a symmetric solution.

The focused differential test is:

`cfemm/fpproc/test/a3_2_mesher_differential_test.cpp`

and is registered as CTest `a3_2_mesher_differential`.

For every fixture the test reparses a fresh `FemmProblem` and explicitly runs both:

- `TriangleMesherBackend`
- `TangleMesherBackend`

The configured/default mesher is therefore not used for the differential comparison.

### Structural mesh checks

For every Triangle/Tangle mesh the test requires:

- successful meshing;
- a valid result from `validateSolverMesh()`;
- non-empty nodes, elements, and edges;
- zero `airGaps`;
- the expected presence/absence of periodic constraints;
- the expected periodicity type (`Periodic` or `Antiperiodic`).

For the periodic and antiperiodic synthetic fixtures it also checks the known seam geometry directly:

- each PBC constraint must connect the lower boundary (`y=-1`) to the upper boundary (`y=+1`), in either endpoint order;
- paired nodes must have matching x coordinates within a tight geometric tolerance;
- every non-corner node on both paired seams must participate in exactly one PBC relation.

The test deliberately does **not** require Triangle and Tangle to have identical node counts, element counts, edge counts, node numbering, element ordering, connectivity, PBC-pair counts, or triangulations.

### Solver and post-processing checks

Each mesh is solved through the real production path using:

- `AnalysisSession`;
- `FSolverAnalysisBackend`;
- `FSolverAnalysisBackend::solvedSolver()` / `solvedSystem()`;
- `FPProc::OpenDocument(...)` for in-memory post-processing.

No `.ans` round-trip is used for the differential comparison.

The sampled physical coordinates are:

- `(-0.60, -0.55)`
- `(-0.55, 0.40)`
- `(-0.20, 0.20)`
- `(0.70, 0.45)`
- `(0.275, -0.25)`

These are chosen away from the exterior seams and, except for the intentionally interior current-region sample, away from material interfaces.

At each sample the test compares Triangle vs Tangle values for:

- magnetic vector potential `A`;
- `B1`;
- `B2`.

It also selects all blocks and compares whole-domain:

- magnetic field energy, `BlockIntegral(2)`;
- magnetic field coenergy, `BlockIntegral(17)`.

Because the fixtures use fixed-A boundary conditions, the gauge is fixed and direct comparison of `A` is meaningful.

### Numerical guards

The common comparator uses:

`abs(a-b) <= absTol + relTol * max(abs(a), abs(b))`

and now explicitly rejects non-finite operands and non-finite/overflowed differences or tolerances. The test includes direct guard probes for NaN, infinity, and overflow cases so catastrophic numerical failures cannot silently pass.

The solved problems must also remain non-trivial: each backend must produce finite positive magnetic energy and at least one sampled magnetic-field magnitude above a conservative numerical-zero threshold.

### Fixture-specific tolerances

The current tolerances, re-established after introducing the asymmetric fixtures, are:

| Fixture | A tolerance `(abs, rel)` | B tolerance `(abs, rel)` | Energy/coenergy tolerance `(abs, rel)` |
|---|---:|---:|---:|
| Non-periodic | `(5e-5, 0.2%)` | `(1.5e-3 T, 2.0%)` | `(0.1 J, 0.25%)` |
| Periodic | `(5e-5, 0.35%)` | `(1.3e-3 T, 1.5%)` | `(0.1 J, 0.55%)` |
| Antiperiodic | `(5e-5, 0.4%)` | `(1.3e-3 T, 2.0%)` | `(0.1 J, 0.65%)` |

The differential executable prints the Triangle value, Tangle value, absolute difference, and permitted tolerance for every sampled/global comparison. The strengthened fixture/test was run repeatedly during development and the complete GitHub Actions matrix passes on the current head.

### In-memory post-processing fix exposed by the new fixtures

The new two-material fixtures exposed a small issue in `FPProc::OpenDocument(...)`: `CMMaterialProp`'s legacy copy constructor does not preserve all transient post-processing state, so vector growth could re-copy an already prepared material and lose such state.

`InMemorySolution.cpp` now reserves `solver.blockproplist.size()` before copying materials into `blockproplist`, preventing those intermediate reallocation copies. This is a local fix required by the in-memory differential path; it does not change mesher or solver physics.

### Scope

This PR is strictly A3.2:

- AGE differential testing is deferred to A3.3;
- the default mesher is unchanged;
- no `MeshingRequest`, `InstancedMesh`, topology-only boundary matching, Tangle in-memory input API, mesher algorithm, or solver-physics changes are introduced.

`docs/instanced-mesh-task-breakdown.md` marks A3.2 complete.

### Testing

The updated head passes the complete GitHub Actions CMake workflow matrix, including Triangle and Tangle CMake builds/tests, Python, GNU Octave, MATLAB MEX, and PETSc jobs.

The A3.2 differential test was also run repeatedly during development to confirm deterministic behaviour. Existing solver-mesh validator, Triangle/Tangle backend, `AnalysisSession`/FSolver, and FPProc snapshot/in-memory tests remain enabled.

AGE is deliberately excluded from these fixtures and remains the next differential stage in A3.3.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9867143d0c8326a5ac69624c44ed3a)