### PR TITLE
fsolver: fix series-circuit excitation in analysis sessions

### DIFF
--- a/cfemm/fsolver/FSolverAnalysisBackend.cpp
+++ b/cfemm/fsolver/FSolverAnalysisBackend.cpp
@@ -63,19 +63,30 @@ void FSolverAnalysisBackend::configure(const ModelDefinition &model,
     // Mesher region attributes are sequential over material-bearing labels;
     // FEMM hole labels do not consume a region number. Mirror that convention
     // in the solver-side label list so regionAttribute - 1 remains valid.
-    for (const auto &item : problem.labellist) {
-        auto label = magneticCopy<CMBlockLabel>(item, "block label");
-        if (!label.isHole())
+    // rawToSolverLabel is a byproduct of this same pass (not a separate,
+    // independently-maintained index): PreparedCircuit::labelIndex (below)
+    // indexes the unfiltered problem.labellist, holes included, so it needs
+    // this translation to address m_solver->labellist correctly. -1 marks a
+    // raw index that was a hole and has no solver-side counterpart.
+    std::vector<int> rawToSolverLabel(problem.labellist.size(), -1);
+    for (std::size_t rawIdx = 0; rawIdx < problem.labellist.size(); ++rawIdx) {
+        auto label = magneticCopy<CMBlockLabel>(problem.labellist[rawIdx], "block label");
+        if (!label.isHole()) {
+            rawToSolverLabel[rawIdx] = static_cast<int>(m_solver->labellist.size());
             m_solver->labellist.push_back(std::move(label));
+        }
     }
     m_solver->circproplist.clear();
     for (std::size_t i = 0; i < problem.circproplist.size(); ++i) {
         auto circuit = magneticCopy<CMCircuit>(problem.circproplist[i], "circuit");
         const auto constraint = parameters.circuitConstraints.at(CircuitId{i});
+        if (constraint.kind != CircuitConstraintKind::PrescribedCurrent)
+            throw std::invalid_argument(
+                "FSolverAnalysisBackend currently supports prescribed-current "
+                "circuit constraints only");
         circuit.Amps = constraint.value;
-        circuit.Case = constraint.kind == CircuitConstraintKind::PrescribedCurrent ? 0 : 2;
-        circuit.dVolts = constraint.kind == CircuitConstraintKind::PrescribedVoltage
-                       ? constraint.value : CComplex();
+        circuit.Case = 0;
+        circuit.dVolts = CComplex();
         m_solver->circproplist.push_back(circuit);
     }
     m_solver->NumPointProps = static_cast<int>(m_solver->nodeproplist.size());
@@ -83,6 +94,44 @@ void FSolverAnalysisBackend::configure(const ModelDefinition &model,
     m_solver->NumBlockProps = static_cast<int>(m_solver->blockproplist.size());
     m_solver->NumBlockLabels = static_cast<int>(m_solver->labellist.size());
     m_solver->NumCircProps = m_solver->NumCircPropsOrig = static_cast<int>(m_solver->circproplist.size());
+
+    // Expand "series" circuits (CircType==1) into one sub-circuit per member
+    // block label, each carrying Amps*signedTurns, then relabel every
+    // circuit as CircType==0 ("parallel"). Static2D only derives a
+    // prescribed-current drive (J from Amps) on the CircType==0 path;
+    // without this expansion a series circuit falls through to the
+    // dVolts-driven branch with dVolts left at zero, silently solving a
+    // zero-excitation problem. Mirrors the classic solver's preprocessing in
+    // fsolver.cpp (circuit serial handling), but driven by prepared.circuits
+    // (AnalysisSession::rebuildCircuits()) rather than re-scanning labellist:
+    // that structure already enumerates exactly the circuit-bearing labels
+    // with their signed turns -- only the index translation above
+    // (rawToSolverLabel) was missing to consume it correctly here.
+    {
+        const int numOrigCirc = m_solver->NumCircProps;
+        m_solver->circproplist.resize(numOrigCirc + m_solver->NumBlockLabels);
+        for (int k = 0; k < numOrigCirc; ++k)
+            m_solver->circproplist[k].OrigCirc = -1;
+
+        for (const auto &entry : prepared.circuits) {
+            const int ic = static_cast<int>(entry.source.value);
+            if (m_solver->circproplist[ic].CircType != 1)
+                continue;
+            const int solverLabelIdx = rawToSolverLabel[entry.labelIndex];
+            if (solverLabelIdx < 0)
+                continue; // A hole label cannot carry a mesh region or current; nothing to drive.
+            auto ncirc = m_solver->circproplist[ic];
+            ncirc.OrigCirc = ic;
+            ncirc.Amps.im *= entry.signedTurns;
+            ncirc.Amps.re *= entry.signedTurns;
+            m_solver->circproplist[m_solver->NumCircProps] = ncirc;
+            m_solver->labellist[solverLabelIdx].InCircuit = m_solver->NumCircProps;
+            ++m_solver->NumCircProps;
+        }
+        for (int k = 0; k < m_solver->NumCircProps; ++k)
+            if (m_solver->circproplist[k].CircType == 1)
+                m_solver->circproplist[k].CircType = 0;
+    }
 }
 
 void FSolverAnalysisBackend::positionAirGaps(const PreparedAnalysis &prepared)
@@ -200,7 +249,11 @@ TrialSolution FSolverAnalysisBackend::solve(const ModelDefinition &model,
         result.real->nodal.x.push_back(node.x / 100.0);
         result.real->nodal.y.push_back(node.y / 100.0);
     }
-    for (std::size_t i = 0; i < m_solver->circproplist.size(); ++i) {
+    // Report only the original, user-visible circuits: configure() may have
+    // appended internal per-label sub-circuits past NumCircPropsOrig to
+    // expand series circuits (see configure()), and those have no entry in
+    // circuitConstraints.
+    for (std::size_t i = 0; i < static_cast<std::size_t>(m_solver->NumCircPropsOrig); ++i) {
         const auto &constraint = parameters.circuitConstraints.at(CircuitId{i});
         CComplex current = constraint.kind == CircuitConstraintKind::PrescribedCurrent
                          ? constraint.value : m_solver->circproplist[i].Amps;

--- a/cfemm/fsolver/test/analysis_session_test.cpp
+++ b/cfemm/fsolver/test/analysis_session_test.cpp
@@ -255,4 +255,27 @@ int main()
     assert(concrete->rightHandSideAssemblyCount() <= evaluations);
     assert(concrete->meshFileWriteCount() == 0);
     assert(concrete->meshFileReadCount() == 0);
+
+    const auto &solved = concrete->solvedSolver();
+    assert(solved.NumCircProps == 3);
+    assert(solved.labellist[0].InCircuit == 1);
+    assert(solved.labellist[1].InCircuit == 2);
+    assert(solved.circproplist[1].Amps == CComplex(110, 0));
+    assert(solved.circproplist[2].Amps == CComplex(-55, 0));
+
+    auto parallelProblem = makeProblem();
+    dynamic_cast<femm::CMCircuit *>(parallelProblem->circproplist[0].get())->CircType = 0;
+    auto parallelBackend = std::make_shared<femm::FSolverAnalysisBackend>();
+    auto parallelMesher = std::make_shared<RecordingMesher>();
+    femm::AnalysisSession parallelSession(femm::ModelDefinition(std::move(parallelProblem)),
+                                          parallelMesher, parallelBackend);
+    parallelSession.setCircuitVoltage(parallelSession.model().circuit("phase-a"),
+                                      CComplex(5, 0));
+    bool parallelVoltageRejected = false;
+    try {
+        parallelSession.solve();
+    } catch (const std::invalid_argument &) {
+        parallelVoltageRejected = true;
+    }
+    assert(parallelVoltageRejected);
 }

--- a/cfemm/fsolver/test/analysis_session_test.cpp
+++ b/cfemm/fsolver/test/analysis_session_test.cpp
@@ -8,6 +8,7 @@
 #include "MesherBackend.h"
 
 #include <cassert>
+#include <cmath>
 #include <memory>
 #include <stdexcept>
 
@@ -57,7 +58,12 @@ public:
         lastPeriodic = periodic;
         femm::mesh::MeshResult result;
         result.status = femm::mesh::MeshStatus::Success;
-        result.mesh.nodes = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}};
+        // Marker two selects the first point property (SolverMesh.h: a node
+        // marker m maps to point property m - 2). Pinning one node to A = 0
+        // makes the single-element patch well posed; without a Dirichlet
+        // constraint the stiffness matrix is singular and a nonzero
+        // excitation drives the solution to infinity.
+        result.mesh.nodes = {{0, 0, 2}, {1, 0, 0}, {0, 1, 0}};
         result.mesh.elements.push_back({{{0, 1, 2}}, 1});
         result.mesh.edges = {{0, 1, 0}, {1, 2, 0}, {2, 0, 0}};
         return result;
@@ -107,6 +113,13 @@ std::unique_ptr<femm::FemmProblem> makeHoleRegionProblem()
 std::unique_ptr<femm::FemmProblem> makeProblem()
 {
     auto problem = std::make_unique<femm::FemmProblem>(femm::FileType::MagneticsFile);
+
+    // RecordingMesher tags one node with this property so that the mesh
+    // carries a Dirichlet constraint.
+    auto point = std::make_unique<femm::CMPointProp>();
+    point->PointName = "fixed";
+    point->A = 0;
+    problem->nodeproplist.push_back(std::move(point));
 
     auto material = std::make_unique<femm::CMMaterialProp>();
     material->BlockName = "steel";
@@ -235,13 +248,14 @@ int main()
     assert(concrete->topologyImportCount() == 1);
     assert(concrete->orderingCount() == 1);
     constexpr int evaluations = 3;
+    femm::TrialSolution lastTrial;
     for (int step = 0; step < evaluations; ++step) {
         concreteSession.setCircuitCurrent(concreteSession.model().circuit("phase-a"),
                                           CComplex(9 + step, 0));
         concreteSession.setAirGapAngle(concreteSession.model().airGap("rotor-gap"),
                                        4 + step, 5);
         concreteSession.setTime(0.01 * step);
-        concreteSession.solve();
+        lastTrial = concreteSession.solve();
     }
     assert(concreteMesher->calls == 1);
     assert(concreteSession.meshGenerationCount() == 1);
@@ -262,6 +276,13 @@ int main()
     assert(solved.labellist[1].InCircuit == 2);
     assert(solved.circproplist[1].Amps == CComplex(110, 0));
     assert(solved.circproplist[2].Amps == CComplex(-55, 0));
+    // The expanded excitation must produce a finite field. A singular,
+    // unconstrained patch would still be reported as solved by the legacy
+    // conjugate-gradient backend while returning infinities, and would make
+    // the PETSc backend report a divergence instead.
+    assert(lastTrial.real);
+    for (double a : lastTrial.real->nodal.magneticVectorPotential)
+        assert(std::isfinite(a));
 
     auto parallelProblem = makeProblem();
     dynamic_cast<femm::CMCircuit *>(parallelProblem->circproplist[0].get())->CircType = 0;


### PR DESCRIPTION
Series windings solved through `AnalysisSession` can produce a zero-excitation field while reporting success: the session backend does not perform the per-label circuit expansion used by the classic solver.

## Context and authorship

This contribution was developed with **Claude Code and OpenAI Codex**, under the submitter's direction, while debugging an **xfemm + MATLAB workflow for nonlinear, planar magnetostatic analysis of a synchronous reluctance motor**. The workflow sweeps d/q currents and rotor angles and extracts torque, flux linkages, energy and local B-field samples. AI agents wrote and revised the code and ran local checks. This is not presented as an independently human-audited solver change; the validation and gaps below are explicit so maintainers can assess it.

## Change

- Consume `prepared.circuits` to expand series windings into per-label subcircuits carrying `Amps * signedTurns`.
- Translate original label indices to the solver's filtered label indices, accounting for holes.
- Report only original user-visible circuits.
- Reject voltage, open and coupled constraints for both series and parallel circuits: this backend currently implements prescribed-current excitation only.
- Extend the existing session test to check signed-turn expansion and rejection of a parallel voltage constraint.

For example, a series circuit at 11 A with labels of +10 and -5 turns produces internal excitations of +110 and -55 ampere-turns.

## Validation and scope

Windows x64 / MinGW, CMake: the combined development checkout passed all 9 tests labelled `unit`, after explicitly running the AGE fixture producer. The tests include `analysis_session`. The suite relies on a generated AGE `.ans`; filtering by `unit` alone does not generate that prerequisite on a fresh build.

The new assertions check circuit conversion, not an analytical nonzero-field reference. The circuit-only commit has not yet been built and tested in an isolated checkout; the combined checkout also contained separate warm-start and Windows Triangle changes. These are limitations of the submitted validation, not a claim of isolated branch parity.

This PR contains no warm-start or Triangle edits. The companion warm-start proposal depends on this correction.
