### PR TITLE
fsolver: warm-start planar magnetostatic analysis sessions

### DIFF
--- a/cfemm/fsolver/FSolverAnalysisBackend.cpp
+++ b/cfemm/fsolver/FSolverAnalysisBackend.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <stdexcept>
+#include <string>
 
 namespace femm {
 namespace {
@@ -188,10 +189,14 @@ void FSolverAnalysisBackend::synchronize(const ModelDefinition &model,
                                          const SolveParameters &parameters,
                                          const PreparedAnalysis &prepared,
                                          std::shared_ptr<const mesh::SolverMesh> mesh,
-                                         std::uint64_t topologyIdentity, Dirty)
+                                         std::uint64_t topologyIdentity, Dirty rebuilt)
 {
     if (!mesh)
         throw std::invalid_argument("FSolver backend requires a mesh");
+    if ((rebuilt & Dirty::PreparedMaterials) != Dirty::None) {
+        m_haveConvergedSolution = false;
+        m_seedSolution.clear();
+    }
     configure(model, parameters, prepared);
     if (topologyIdentity != m_topologyIdentity) {
         const auto meshError = m_solver->LoadMesh(*mesh);
@@ -216,25 +221,45 @@ TrialSolution FSolverAnalysisBackend::solve(const ModelDefinition &model,
                                             const SolveParameters &parameters,
                                             const PreparedAnalysis &prepared)
 {
-    // Static2D/StaticAxisymmetric currently assemble both parts of a fresh
-    // linear system on every evaluation.  Keep the two counters separate so
-    // future dirty-flag based reuse can be introduced without changing the API.
+    // Seed a fresh linear system from the previous converged nodal field.
     ++m_operatorAssemblies;
     ++m_rightHandSideAssemblies;
     configure(model, parameters, prepared);
     if (parameters.frequency != 0)
         throw std::invalid_argument("FSolverAnalysisBackend currently returns real (zero-frequency) solutions only");
+    const bool incrementalRequested = !model.problem().previousSolutionFile.empty() &&
+                                       model.problem().PrevType != 0;
+    const bool canWarmStart = m_haveConvergedSolution &&
+                               m_solutionTopologyIdentity == m_topologyIdentity &&
+                               static_cast<int>(m_seedSolution.size()) == m_solver->NumNodes &&
+                               !incrementalRequested;
     m_lastSystem = femm::create_backend<double>(femm::default_backend_kind());
     if (!m_lastSystem)
         throw std::runtime_error("FSolver could not create the linear system backend");
-    femm::LinearSystemBackend<double> &system = *m_lastSystem;
-    system.set_precision(m_solver->Precision);
-    if (!system.create(m_solver->NumNodes, m_solver->BandWidth))
+    m_lastSystem->set_precision(m_solver->Precision);
+    if (!m_lastSystem->create(m_solver->NumNodes, m_solver->BandWidth))
         throw std::runtime_error("FSolver could not allocate the linear system");
-    const bool solved = m_solver->ProblemType == PLANAR
-                      ? m_solver->Static2D(system) : m_solver->StaticAxisymmetric(system);
+    femm::LinearSystemBackend<double> &system = *m_lastSystem;
+    if (canWarmStart) {
+        auto &solution = system.solution();
+        for (std::size_t j = 0; j < m_seedSolution.size(); ++j)
+            solution[j] = m_seedSolution[j];
+    }
+    m_solver->WarmStartSeeded = canWarmStart && (m_solver->ProblemType == PLANAR);
+    const int solveStatus = m_solver->ProblemType == PLANAR
+                           ? m_solver->Static2D(system) : m_solver->StaticAxisymmetric(system);
+    const bool solved = (solveStatus == 1);
+    m_solver->WarmStartSeeded = false;
+    m_haveConvergedSolution = solved;
+    m_solutionTopologyIdentity = m_topologyIdentity;
+    if (solved && m_solver->ProblemType == PLANAR) {
+        m_seedSolution.assign(system.solution().begin(), system.solution().end());
+    } else {
+        m_seedSolution.clear();
+    }
     if (!solved)
-        throw std::runtime_error("FSolver failed to solve the analysis");
+        throw std::runtime_error("FSolver failed to solve the analysis (status " +
+                                 std::to_string(solveStatus) + ")");
     ++m_solves;
 
     TrialSolution result;

--- a/cfemm/fsolver/FSolverAnalysisBackend.h
+++ b/cfemm/fsolver/FSolverAnalysisBackend.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <vector>
 
 namespace femm {
 
@@ -50,6 +51,10 @@ private:
     std::unique_ptr<femm::LinearSystemBackend<double>> m_lastSystem;
     std::shared_ptr<const mesh::SolverMesh> m_mesh;
     std::uint64_t m_topologyIdentity = 0;
+    // Previous converged nodal field used to seed planar Newton solves.
+    std::uint64_t m_solutionTopologyIdentity = 0;
+    bool m_haveConvergedSolution = false;
+    std::vector<double> m_seedSolution;
     std::size_t m_topologyImports = 0;
     std::size_t m_orderings = 0;
     std::size_t m_couplingRegenerations = 0;

--- a/cfemm/fsolver/fsolver.h
+++ b/cfemm/fsolver/fsolver.h
@@ -94,6 +94,8 @@ public:
     bool LoadPBCFromSolution(FILE* fp);
     bool LoadAGEsFromSolution(FILE* fp);
     bool LoadProblemFile();
+    /** True when solution() contains a converged planar Newton seed. */
+    bool WarmStartSeeded = false;
     int Static2D(femm::LinearSystemBackend<double> &L);
     /**
      * @brief WriteStatic2D

--- a/cfemm/fsolver/static2d.cpp
+++ b/cfemm/fsolver/static2d.cpp
@@ -604,35 +604,42 @@ int FSolver::Static2D(femm::LinearSystemBackend<double> &L)
             {
                 k = meshele[i].blk;
 
-                if (blockproplist[k].LamType==0)
+                if (!WarmStartSeeded)
                 {
-                    t = blockproplist[k].LamFill;
-                    meshele[i].mu1 = blockproplist[k].mu_x*t + (1.-t);
-                    meshele[i].mu2 = blockproplist[k].mu_y*t + (1.-t);
-                }
-                if (blockproplist[k].LamType==1)
-                {
-                    t = blockproplist[k].LamFill;
-                    mu = blockproplist[k].mu_x;
-                    meshele[i].mu1 = mu*t + (1.-t);
-                    meshele[i].mu2 = mu/(t + mu*(1.-t));
-                }
-                if (blockproplist[k].LamType==2)
-                {
-                    t = blockproplist[k].LamFill;
-                    mu = blockproplist[k].mu_y;
-                    meshele[i].mu2 = mu*t + (1.-t);
-                    meshele[i].mu1 = mu/(t + mu*(1.-t));
-                }
-                if (blockproplist[k].LamType>2)
-                {
-                    meshele[i].mu1 = 1;
-                    meshele[i].mu2 = 1;
+                    if (blockproplist[k].LamType==0)
+                    {
+                        t = blockproplist[k].LamFill;
+                        meshele[i].mu1 = blockproplist[k].mu_x*t + (1.-t);
+                        meshele[i].mu2 = blockproplist[k].mu_y*t + (1.-t);
+                    }
+                    if (blockproplist[k].LamType==1)
+                    {
+                        t = blockproplist[k].LamFill;
+                        mu = blockproplist[k].mu_x;
+                        meshele[i].mu1 = mu*t + (1.-t);
+                        meshele[i].mu2 = mu/(t + mu*(1.-t));
+                    }
+                    if (blockproplist[k].LamType==2)
+                    {
+                        t = blockproplist[k].LamFill;
+                        mu = blockproplist[k].mu_y;
+                        meshele[i].mu2 = mu*t + (1.-t);
+                        meshele[i].mu1 = mu/(t + mu*(1.-t));
+                    }
+                    if (blockproplist[k].LamType>2)
+                    {
+                        meshele[i].mu1 = 1;
+                        meshele[i].mu2 = 1;
+                    }
                 }
 
                 if (blockproplist[k].BHpoints != 0)
                 {
-                    if (bIncremental == MS_LEGACY_FALSE)
+                    if (WarmStartSeeded)
+                    {
+                        LinearFlag = false;
+                    }
+                    else if (bIncremental == MS_LEGACY_FALSE)
                     {
                         // There's no previous solution.  This is a standard nonlinear problem
                         LinearFlag = false;
@@ -946,7 +953,7 @@ int FSolver::Static2D(femm::LinearSystemBackend<double> &L)
         }
 
         femm::SolveOptions opts;
-        opts.warm_start = (Iter > 0);
+        opts.warm_start = (Iter > 0) || WarmStartSeeded;
         if (L.solve(opts).converged==false)
         {
             return false;
@@ -1007,7 +1014,7 @@ int FSolver::Static2D(femm::LinearSystemBackend<double> &L)
         // nonlinear iteration has to have a looser tolerance
         // than the linear solver--otherwise, things can't ever
         // converge.  Arbitrarily choose 100*tolerance.
-        if((res<100.*Precision) && (Iter>0))
+        if((res<100.*Precision) && (Iter>0 || WarmStartSeeded))
         {
             LinearFlag = true;
         }


### PR DESCRIPTION
Repeated planar magnetostatic solves through `AnalysisSession` currently start from the cold permeability bootstrap. This proposal reuses a previous converged nodal field and the retained element permeability estimates for nearby operating points.

## Context and authorship

This contribution was developed with **Claude Code and OpenAI Codex**, under the submitter's direction, for an **xfemm + MATLAB nonlinear magnetostatic workflow**: synchronous reluctance motor current/rotor-angle sweeps, with torque, flux, energy and local B-field extraction. AI agents implemented, reviewed and tested the changes. Maintainer review is requested; automated checks and application benchmarks are not represented as independent human verification.

## Implementation

- Copy the previous converged planar nodal field into a freshly allocated linear system, retaining the solver's element permeability estimates for iteration zero.
- Allow the linear solve to use this initial guess and allow convergence at the first nonlinear iteration.
- Invalidate the seed on `Dirty::PreparedMaterials`; require matching mesh topology and node count.
- Disable this warm start for incremental/frozen-permeability requests and axisymmetric solves.
- Treat only solver status `1` as success, so an error such as `-7` cannot become a cached converged seed.

The matrix is rebuilt for every solve. Reusing the sparse matrix across moving air-gap positions accumulated entries and degraded performance during exploratory sweeps. The final implementation retains a nodal vector, not the sparse matrix. Material invalidation uses the existing dirty-state mechanism rather than duplicating material-field comparisons.

## Dependency

Depends on #58. This branch is stacked on `fix/analysis-session-series-circuits`. Against upstream `master`, its diff includes that prerequisite commit. Review #58 first; the warm-start-specific commit is `123f1f9`. Rebase onto upstream after the circuit correction is merged.

## Validation and remaining work

The final simplified C++ implementation built successfully and passed 6 targeted CTest cases: `analysis_session`, `periodic_pbc_without_age`, and the setup/mesh/solve cases for `fsolver_Temp` and `fsolver_Temp1`. Earlier, the combined development checkout passed all 9 unit-labelled tests. These runs used the separate Windows Triangle fix in the working tree, and not every targeted executable was relinked in the final targeted build.

Earlier application experiments used MATLAB R2025b on Windows x64, Id = Iq = 6 A and 65 rotor angles, and compared hot/cold torque and runtime. **The final dirty-state invalidation simplification has not been rebuilt as a MEX or rerun in MATLAB.** Historical timings therefore should not be read as validation of this exact commit.

Draft pending dedicated numerical regressions for nonlinear warm/cold agreement, material-change fallback, topology changes and solver failures. Laminated materials and incremental/frozen-permeability behavior require further review. No axisymmetric warm-start acceleration is claimed.
