### PR TITLE
libfemm: report divergence from the legacy conjugate gradient solver

### DIFF
--- a/cfemm/libfemm/linsolve/LegacyLinearSystemBackend.h
+++ b/cfemm/libfemm/linsolve/LegacyLinearSystemBackend.h
@@ -86,7 +86,8 @@ public:
             m_system.Precision = options.tolerance;
         SolveReport report;
         report.solver = "legacy-pcg";
-        report.converged = m_system.PCGSolve(options.warm_start ? 1 : 0);
+        report.converged = m_system.PCGSolve(options.warm_start ? 1 : 0,
+                                            options.max_iterations);
         return report;
     }
 

--- a/cfemm/libfemm/spars.cpp
+++ b/cfemm/libfemm/spars.cpp
@@ -22,6 +22,7 @@
 #include "femmcomplex.h"
 #include "spars.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -235,7 +236,7 @@ void CBigLinProb::MultPC(const double *X, double *Y)
     }
 }
 
-bool CBigLinProb::PCGSolve(int flag)
+bool CBigLinProb::PCGSolve(int flag, int maxIterations)
 {
     int i;
     double res,res_o,res_new;
@@ -270,7 +271,14 @@ bool CBigLinProb::PCGSolve(int flag)
     for(i=0; i<n; i++) P[i]=Z[i];
     res=Dot(Z,R);
 
+    // Conjugate gradients converge in at most n steps in exact arithmetic,
+    // so n is a ceiling that never rejects a solve the theory says should
+    // have finished; the floor keeps small problems from being cut short by
+    // rounding. Without any ceiling a stalled iteration spins forever.
+    const int iterationLimit = (maxIterations > 0) ? maxIterations : std::max(1000, n);
+
     // do iteration;
+    int iter = 0;
     do
     {
         // step i)
@@ -298,6 +306,17 @@ bool CBigLinProb::PCGSolve(int flag)
 
         // have we converged yet?
         er=sqrt(res/res_o);
+
+        // A breakdown -- a singular or indefinite operator, or a zero pAp --
+        // surfaces as a non-finite residual ratio. The loop condition alone
+        // would treat that as convergence, because NaN > Precision is false,
+        // and the caller would receive an infinite solution reported as good.
+        if (!std::isfinite(er))
+        {
+            fprintf(stderr, "conjugate gradient breakdown after %i iterations\n",
+                    iter + 1);
+            return false;
+        }
 //        prg2=(int) (20.*log10(er)/(log10(Precision)));
 //        if(prg2>prg1)
 //        {
@@ -310,7 +329,16 @@ bool CBigLinProb::PCGSolve(int flag)
 //        }
 
     }
-    while(er>Precision);
+    while(er>Precision && ++iter<iterationLimit);
+
+    if (er>Precision)
+    {
+        fprintf(stderr,
+                "conjugate gradient failed to converge in %i iterations "
+                "(residual ratio %g, requested %g)\n",
+                iterationLimit, er, Precision);
+        return false;
+    }
 
     return true;
 }

--- a/cfemm/libfemm/spars.h
+++ b/cfemm/libfemm/spars.h
@@ -65,7 +65,13 @@ public:
     void Put(double v, int p, int q);
     // use to create/set entries in the matrix
     double Get(int p, int q);
-    bool PCGSolve(int flag);	// flag==true if guess for V present;
+    /** Preconditioned conjugate gradients.
+     *  @param flag non-zero if a starting guess for V is present.
+     *  @param maxIterations iteration ceiling; 0 selects the default.
+     *  @return false if the iteration broke down, or ran out of
+     *          iterations without reaching Precision.
+     */
+    bool PCGSolve(int flag, int maxIterations = 0);
     void MultPC(const double *X, double *Y);
     void AddTo(double v, int p, int q);
     void MultA(double *X, double *Y);


### PR DESCRIPTION
Follow-up to the observation in #58. Independent of it: this branch is cut from current `master` and touches no solver logic that #58 touches.

## Problem

`CBigLinProb::PCGSolve` (`spars.cpp`) returns `true` unconditionally. Its only guard tests for a zero diagonal entry, which a rank-deficient matrix with a full diagonal does not trip, and the iteration loop has no ceiling — it exits once the residual ratio becomes NaN, because `NaN > Precision` is false. A diverging solve is therefore reported as converged and the caller receives infinities as a valid solution.

`LegacyLinearSystemBackend::solve` copies that boolean straight into `SolveReport::converged`, so every caller in the tree inherits the blind spot. `SolveOptions::max_iterations` already exists in the interface and was silently dropped by this backend.

This surfaced while investigating #58, where the PETSc backend failed a test that the legacy backend passed. PETSc was right: the test problem was singular and the legacy backend had been returning `inf` while reporting success.

## Change

- Return `false` on breakdown, detected as a non-finite residual ratio.
- Return `false` on exhausting an iteration ceiling. The ceiling defaults to `max(1000, n)`: conjugate gradients converge in at most `n` steps in exact arithmetic, so `n` never rejects a solve the theory says should have finished, while the floor keeps small problems from being cut short by rounding.
- Honour `SolveOptions::max_iterations` when set, matching how the PETSc backend consumes the same field.
- Both failure paths print a diagnostic naming the iteration count and the residual reached.

## Behaviour change worth flagging

This is user-visible. A model that previously "solved" while diverging will now fail loudly rather than return garbage. That is the intent, but it means someone's currently-passing workflow could start reporting an error — surfacing a pre-existing wrong answer rather than creating a new failure. The iteration ceiling is the part where a judgement call was made; if you would rather it be unbounded and only keep the breakdown guard, that is a one-line change.

## Validation and its limits

Full `ctest` suite on Windows x64 / MinGW, CMake Debug, Triangle backend: **50/50 pass**, unchanged from `master` at `b6e71b4`.

Negative control, to show the new guard is not inert: applying #58's series-circuit commit on top of this branch — which supplies a real excitation to that PR's then-singular test fixture — makes the legacy backend produce

```
conjugate gradient breakdown after 3 iterations
terminate called after throwing an instance of 'std::runtime_error'
  what():  FSolver failed to solve the analysis
```

which is exactly what the PETSc backend already reported for that case. With #58's fixture correction also applied, the whole suite is 50/50 again.

PETSc is not available on the submitter's platform, so the PETSc job was not run locally. Linux, the MEX interfaces and the PETSc backend rest on this PR's CI. Nothing here was tested against a large production model, where the iteration ceiling is the parameter most likely to matter.

## Authorship

This change, its validation and this description were produced by Claude Code under the submitter's direction, as with #58. The submitter does not have the solver-internals background to independently audit it at the level it needs and cannot vouch for it beyond the checks reported above — please treat it as unreviewed by a human expert and weigh it accordingly. It is offered as a starting point, and closing it costs nothing if the trade-off is not one you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
