### PR TITLE
test: match the [Solution] marker without backslash escapes

### DIFF
--- a/cfemm/femmcli/test/validate_solution.cmake
+++ b/cfemm/femmcli/test/validate_solution.cmake
@@ -5,7 +5,10 @@ file(SIZE "${SOLUTION_FILE}" _solution_size)
 if(_solution_size LESS 100)
     message(FATAL_ERROR "Solution file is unexpectedly small: ${_solution_size} bytes")
 endif()
-file(STRINGS "${SOLUTION_FILE}" _solution_marker REGEX "^\[Solution\]$")
+# Match the literal brackets with character classes rather than backslash
+# escapes: CMake 4 no longer forwards \[ from a quoted argument to the regex
+# engine, which silently degraded this pattern into a character class.
+file(STRINGS "${SOLUTION_FILE}" _solution_marker REGEX "^[[]Solution[]]$")
 if(NOT _solution_marker)
     message(FATAL_ERROR "Solution file has no [Solution] section")
 endif()


### PR DESCRIPTION
`femmcli_femfile.check.ans` fails on every build configured with CMake 4 or newer. One line in `cfemm/femmcli/test/validate_solution.cmake`; no solver or library code is touched.

## Cause

The check looks for the `[Solution]` section with

```cmake
REGEX "^\[Solution\]$"
```

CMake 4 no longer forwards a backslash-escaped bracket from a quoted argument through to the regex engine. The pattern therefore arrives at the matcher as `^[Solution]$` — a character class — and looks for a line consisting of a single character drawn from `S o l u t i n`. It can never match the literal `[Solution]` line it exists to find, so the check reports "Solution file has no [Solution] section" for a solution file that is perfectly well formed.

The failure is silent in the sense that nothing is wrong with the solver, the solution file, or the build: only the test's own pattern is degraded.

CI does not see this because its runners still carry a CMake older than 4. That is an inference from the suite being green, not something verified against a runner; the failure will surface on its own when the images move on.

## Change

Express the brackets as character classes, `^[[]Solution[]]$`. That form contains no backslashes at all, so it is unaffected by the parsing change and behaves the same on both CMake generations. A short comment records why, so the pattern is not "tidied" back to backslashes later.

## Verification

Running the validation script directly against a real `femmcli_femfile.result.ans`:

| script | CMake 3.29.2 | CMake 4.4.3 |
|---|---|---|
| current | passes | **fails** |
| this branch | passes | **passes** |

Full suite, Windows x64, MSYS2/UCRT64, Release, CMake 4.4.3, three runs each: 48/50 before, 49/50 after, the difference being exactly this test.

## Not addressed here

The one test still failing in that configuration is `femmcli_moverotate_magdir.check.fem`, and it is a different matter. It compares a produced `.fem` against a checked-in reference byte for byte, and the two differ by a single unit in the last place of a double printed to seventeen digits (`...118654757` against `...118654746`) — the toolchain's math library, not a computation error. Making that check tolerant would be a change of testing policy rather than a bug fix, so it is left alone and simply reported here.

## Authorship

This change and its description were produced by Claude Code under the submitter's direction, as with #58 and #61. The submitter does not have the background to independently audit this at the level it needs and cannot vouch for it beyond the checks reported above — please treat it as unreviewed by a human expert. It is deliberately the smallest change that restores the check; closing it costs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
